### PR TITLE
Develop

### DIFF
--- a/files/queries/summary/gamedata.sql
+++ b/files/queries/summary/gamedata.sql
@@ -18,7 +18,7 @@ from (
         --[not_collection] --[group_by] count() as count,
         results.playtime,
         --[collection_daily] collection_daily as collection,
-        --[collection_weekly] strftime('%Y-%W', collection_daily) as collection,
+        --[collection_weekly] date(collection_daily, '-' || (strftime('%w', collection_daily) -1) || ' days') as collection,
         --[collection_monthly] strftime('%Y-%m', collection_daily) as collection,
         --[collection_yearly] strftime('%Y', collection_daily) as collection,
         --[collection_all] '' as collection,
@@ -59,18 +59,18 @@ from (
     --[not_collection] --[group_by]     --[comment] game_info.comment, name
     --[not_collection] --[group_by]     --[group_length] substr(game_info.comment, 1, :group_length), name
     --[collection] group by
-    --[collection_daily]     collection_daily, name -- 日次集計
-    --[collection_weekly]     strftime('%Y-%W', collection_daily), name
-    --[collection_monthly]     strftime('%Y-%m', collection_daily), name
-    --[collection_yearly]     strftime('%Y', collection_daily), name
+    --[collection_daily]     collection, name -- 日次集計
+    --[collection_weekly]     collection, name
+    --[collection_monthly]     collection, name
+    --[collection_yearly]     collection, name
     --[collection_all]     name -- 全体集計
     order by
         --[not_collection] results.playtime desc
-        --[collection_daily] collection_daily desc
-        --[collection_weekly] strftime('%Y-%W', collection_daily) desc
-        --[collection_monthly] strftime('%Y-%m', collection_daily) desc
-        --[collection_yearly] strftime('%Y', collection_daily) desc
-        --[collection_all] collection_daily desc
+        --[collection_daily] collection desc
+        --[collection_weekly] collection desc
+        --[collection_monthly] collection desc
+        --[collection_yearly] collection desc
+        --[collection_all] collection desc
 )
 window
     --[not_collection] moving as (partition by name order by playtime)

--- a/files/queries/summary/gamedata.sql
+++ b/files/queries/summary/gamedata.sql
@@ -18,7 +18,7 @@ from (
         --[not_collection] --[group_by] count() as count,
         results.playtime,
         --[collection_daily] collection_daily as collection,
-        --[collection_weekly] date(collection_daily, '-' || (strftime('%w', collection_daily) -1) || ' days') as collection,
+        --[collection_weekly] date(collection_daily, '-' || strftime('%w', collection_daily) || ' days', 'weekday 1') as collection,
         --[collection_monthly] strftime('%Y-%m', collection_daily) as collection,
         --[collection_yearly] strftime('%Y', collection_daily) as collection,
         --[collection_all] '' as collection,

--- a/libs/commands/graph/summary.py
+++ b/libs/commands/graph/summary.py
@@ -412,6 +412,9 @@ def _graph_title(graph_params: GraphParams):
             case "daily":
                 kind = Format.YMD_O
                 graph_params.update({"xlabel_text": f"集計日（{graph_params['total_game_count']} ゲーム）"})
+            case "weekly":
+                kind = Format.JYM_O
+                graph_params.update({"xlabel_text": f"集計週（{graph_params['total_game_count']} ゲーム）"})
             case "monthly":
                 kind = Format.JYM_O
                 graph_params.update({"xlabel_text": f"集計月（{graph_params['total_game_count']} ゲーム）"})

--- a/libs/commands/graph/summary.py
+++ b/libs/commands/graph/summary.py
@@ -258,7 +258,7 @@ def _graph_generation(graph_params: GraphParams) -> "Path":
             bbox_to_anchor=(1, 1),
             loc="upper left",
             borderaxespad=0.5,
-            ncol=int(len(target_data) / 25 + 1),
+            ncol=int(len(target_data) / 20 + 1),
         )
 
         # X軸修正


### PR DESCRIPTION
This pull request updates the SQL query logic for weekly data aggregation and improves the clarity and consistency of graph labeling in the summary graph generation code. The main focus is on standardizing how collection periods are handled and displayed, particularly for weekly summaries.

**SQL Query Logic Improvements:**

* Changed weekly aggregation in `gamedata.sql` to use the start date of the week (Monday) instead of the previous `strftime('%Y-%W', ...)` format, ensuring more accurate and consistent weekly grouping.
* Unified the use of the `collection` column for all aggregation periods (daily, weekly, monthly, yearly, all) in both `GROUP BY` and `ORDER BY` clauses, simplifying and standardizing the SQL queries.

**Graph Generation and Labeling Enhancements:**

* Added support for proper weekly x-axis labeling in `_graph_title`, using the same format as monthly, and updated the label text to indicate weekly aggregation.
* Adjusted the legend column calculation in `_graph_generation` to use a divisor of 20 instead of 25, improving the layout for datasets with many entries.