### PR TITLE
Develop

### DIFF
--- a/cls/timekit.py
+++ b/cls/timekit.py
@@ -319,13 +319,13 @@ class ExtendedDatetime:
         match fmt:
             case Format.TS:
                 ret = str(self._dt.timestamp())
-            case Format.Y | Format.JY | Format.JY_O:
+            case Format.Y | Format.JY | Format.Y_O | Format.JY_O:
                 match delimiter:
                     case Delimiter.JAPANESE:
                         ret = self._dt.strftime("%Y年")
                     case _:
                         ret = self._dt.strftime("%Y")
-            case Format.YM | Format.JYM | Format.JYM_O:
+            case Format.YM | Format.JYM | Format.YM_O | Format.JYM_O:
                 match delimiter:
                     case Delimiter.SLASH:
                         ret = self._dt.strftime("%Y/%m")
@@ -337,7 +337,7 @@ class ExtendedDatetime:
                         ret = self._dt.strftime("%Y%m")
                     case _:
                         ret = self._dt.strftime("%Y/%m")
-            case Format.YMD | Format.JYMD | Format.JYMD_O:
+            case Format.YMD | Format.JYMD | Format.YMD_O | Format.JYMD_O:
                 match delimiter:
                     case Delimiter.SLASH:
                         ret = self._dt.strftime("%Y/%m/%d")

--- a/libs/commands/graph/summary.py
+++ b/libs/commands/graph/summary.py
@@ -413,7 +413,7 @@ def _graph_title(graph_params: GraphParams):
                 kind = Format.YMD_O
                 graph_params.update({"xlabel_text": f"集計日（{graph_params['total_game_count']} ゲーム）"})
             case "weekly":
-                kind = Format.JYM_O
+                kind = Format.YMD_O
                 graph_params.update({"xlabel_text": f"集計週（{graph_params['total_game_count']} ゲーム）"})
             case "monthly":
                 kind = Format.JYM_O


### PR DESCRIPTION
This pull request updates date formatting logic to support additional format types and corrects the date format used for weekly graphs. The main changes involve extending format handling in the `format` method and ensuring weekly graphs use a more precise date format.

### Date formatting enhancements

* Expanded the `format` method in `cls/timekit.py` to handle additional format types: `Format.Y_O`, `Format.YM_O`, and `Format.YMD_O`, allowing for more flexible date output options. [[1]](diffhunk://#diff-d302c9907f8a5d3125dfef762461dcf21d672115ebeae55b40a0d1ee65e6b3a3L322-R328) [[2]](diffhunk://#diff-d302c9907f8a5d3125dfef762461dcf21d672115ebeae55b40a0d1ee65e6b3a3L340-R340)

### Graph label formatting

* Updated the `_graph_title` function in `libs/commands/graph/summary.py` to use `Format.YMD_O` for weekly graphs instead of `Format.JYM_O`, ensuring weekly aggregation labels display full dates rather than just year and month.