### PR TITLE
Refactor game.info.sql and GameInfo class to remove unique player and…

### DIFF
--- a/files/queries/game.info.sql
+++ b/files/queries/game.info.sql
@@ -2,21 +2,15 @@
 with target_data as (
     select
         *
-    from (
-        select
-            *,
-            sum(guest) over (partition by playtime) as guest_count,
-            count() over (partition by playtime, team) as same_team
-        from
-            individual_results
-    )
+    from
+        game_info
     where
         mode = :mode
         and rule_version in (<<rule_list>>)
         and playtime between :starttime and :endtime
         --[separate] and source = :source
         --[individual] --[guest_not_skip] and guest_count <= 1 -- ゲストあり(2ゲスト戦除外)
-        --[friendly_fire] and same_team != 0
+        --[friendly_fire] and same_team = 0
         --[search_word] and comment like :search_word
 )
 select distinct
@@ -24,9 +18,7 @@ select distinct
     first_value(playtime) over (order by playtime rows between unbounded preceding and unbounded following) as first_game,
     last_value(playtime) over (order by playtime rows between unbounded preceding and unbounded following) as last_game,
     first_value(comment) over (order by playtime rows between unbounded preceding and unbounded following) as first_comment,
-    last_value(comment) over (order by playtime rows between unbounded preceding and unbounded following) as last_comment,
-    (select count(distinct name) from target_data) as unique_name,
-    (select count(distinct team) from target_data) as unique_team
+    last_value(comment) over (order by playtime rows between unbounded preceding and unbounded following) as last_comment
 from
     target_data
 ;

--- a/libs/datamodels.py
+++ b/libs/datamodels.py
@@ -31,10 +31,6 @@ class GameInfo:
     """集計範囲の最初のゲームコメント"""
     last_comment: Optional[str] = field(default=None)
     """集計範囲の最後のゲームコメント"""
-    unique_name: int = field(default=0)
-    """集計範囲のユニークプレイヤー数"""
-    unique_team: int = field(default=0)
-    """集計範囲のユニークチーム数"""
 
     def __post_init__(self):
         self.get()
@@ -66,8 +62,6 @@ class GameInfo:
             self.last_game = ExtDt(df["last_game"].to_string(index=False))
             self.first_comment = str(df["first_comment"].to_string(index=False))
             self.last_comment = str(df["last_comment"].to_string(index=False))
-            self.unique_name = int(df["unique_name"].to_string(index=False))
-            self.unique_team = int(df["unique_team"].to_string(index=False))
 
         # 規定打数更新
         if not g.params.get("stipulated", 0):  # 規定打数0はレートから計算


### PR DESCRIPTION
This pull request simplifies the game information summary by removing the calculation and reporting of unique player and team counts. The changes affect both the SQL query and the corresponding data model, ensuring consistency between data retrieval and representation.

**Game info summary simplification:**

* Removed calculation of `unique_name` (unique player count) and `unique_team` (unique team count) from the SQL query `files/queries/game.info.sql`.
* Removed the `unique_name` and `unique_team` fields from the `GameInfo` data class in `libs/datamodels.py`, along with their initialization in the `get` method. [[1]](diffhunk://#diff-a641d02a5298e4a63d02744c0e7b131d56acec994ac153f7c7e3af87cf52b46fL34-L37) [[2]](diffhunk://#diff-a641d02a5298e4a63d02744c0e7b131d56acec994ac153f7c7e3af87cf52b46fL69-L70)… team counts