### PR TITLE
Develop

### DIFF
--- a/files/queries/record.info.sql
+++ b/files/queries/record.info.sql
@@ -26,9 +26,9 @@ with base_tbl as (
         --[individual] --[guest_not_skip] and guest_count <= 1 -- ゲストアリ(2ゲスト戦除外)
         --[individual] --[guest_skip] and guest = 0 -- ゲストナシ
         --[individual] --[player_name] and name in (<<player_list>>) -- 対象プレイヤー
-        --[team] and team != '未所属' -- 未所属除外
+        --[team] and name != '未所属' -- 未所属除外
         --[team] --[friendly_fire] and same_team != 0
-        --[team] --[player_name] and team in (<<player_list>>) -- 対象チーム
+        --[team] --[player_name] and name in (<<player_list>>) -- 対象チーム
         --[search_word] and comment like :search_word
 ),
 all_tbl as (

--- a/integrations/standard_io/api.py
+++ b/integrations/standard_io/api.py
@@ -78,7 +78,7 @@ class AdapterAPI(APIInterface):
                         disp = disp.replace("0.00", "-.--")
                     print(disp)
                 case x if isinstance(x, Path):
-                    print(f"{title}: {x.absolute()}")
+                    print(f"{options.title}: {x.absolute()}")
                 case _:
                     pass
 

--- a/libs/commands/report/stats_report.py
+++ b/libs/commands/report/stats_report.py
@@ -549,7 +549,7 @@ def entire_aggregate(style: dict) -> list:
     plt.title("順位分布 （ 全期間 ）", fontsize=18)
     plt.ylabel("")
     plt.legend(
-        handles=list(gdata.index),
+        labels=list(gdata.index),
         bbox_to_anchor=(0.5, -0.1),
         loc="lower center",
         ncol=4,

--- a/tests/test.py
+++ b/tests/test.py
@@ -119,7 +119,7 @@ def test_pattern(flag: dict, test_case: str, sec: str, pattern: str, argument: s
                 pprint(compose.msg_print.help_message(m), width=200)
 
             case "summary":
-                g.cfg.results.always_argument = add_argument
+                m.data.text = f"{g.cfg.results.commandword[0]} {' '.join(add_argument)}"
                 g.params = dictutil.placeholder(g.cfg.results, m)
                 pprint(
                     [
@@ -131,7 +131,7 @@ def test_pattern(flag: dict, test_case: str, sec: str, pattern: str, argument: s
                 )
 
             case "graph":
-                g.cfg.graph.always_argument = add_argument
+                m.data.text = f"{g.cfg.graph.commandword[0]} {' '.join(add_argument)}"
                 g.params = dictutil.placeholder(g.cfg.graph, m)
                 if g.params.get("filename"):
                     save_filename = g.params["filename"]
@@ -152,22 +152,22 @@ def test_pattern(flag: dict, test_case: str, sec: str, pattern: str, argument: s
                         graph_statistics(m)
 
             case "graph_point":
-                g.cfg.graph.always_argument = add_argument
+                m.data.text = f"{g.cfg.graph.commandword[0]} {' '.join(add_argument)}"
                 g.params = dictutil.placeholder(g.cfg.graph, m)
                 graph_point(m)
 
             case "graph_rank":
-                g.cfg.graph.always_argument = add_argument
+                m.data.text = f"{g.cfg.graph.commandword[0]} {' '.join(add_argument)}"
                 g.params = dictutil.placeholder(g.cfg.graph, m)
                 graph_rank(m)
 
             case "graph_statistics":
-                g.cfg.graph.always_argument = add_argument
+                m.data.text = f"{g.cfg.graph.commandword[0]} {' '.join(add_argument)}"
                 g.params = dictutil.placeholder(g.cfg.graph, m)
                 graph_statistics(m)
 
             case "ranking":
-                g.cfg.ranking.always_argument = add_argument
+                m.data.text = f"{g.cfg.ranking.commandword[0]} {' '.join(add_argument)}"
                 g.params = dictutil.placeholder(g.cfg.ranking, m)
 
                 pprint(
@@ -180,7 +180,7 @@ def test_pattern(flag: dict, test_case: str, sec: str, pattern: str, argument: s
                 )
 
             case "report":
-                g.cfg.report.always_argument = add_argument
+                m.data.text = f"{g.cfg.report.commandword[0]} {' '.join(add_argument)}"
                 g.params = dictutil.placeholder(g.cfg.report, m)
                 pprint(
                     [
@@ -192,7 +192,7 @@ def test_pattern(flag: dict, test_case: str, sec: str, pattern: str, argument: s
                 )
 
             case "pdf":
-                g.cfg.report.always_argument = add_argument
+                m.data.text = f"{g.cfg.report.commandword[0]} {' '.join(add_argument)}"
                 g.params = dictutil.placeholder(g.cfg.report, m)
                 pprint(
                     [
@@ -204,7 +204,7 @@ def test_pattern(flag: dict, test_case: str, sec: str, pattern: str, argument: s
                 )
 
             case "rating":
-                g.cfg.results.always_argument = add_argument
+                m.data.text = f"{g.cfg.ranking.commandword[0]} {' '.join(add_argument)}"
                 g.params = dictutil.placeholder(g.cfg.results, m)
                 pprint(
                     [


### PR DESCRIPTION
This pull request includes several improvements and bug fixes across SQL queries, Python plotting, I/O handling, and test code. The main focus is on correcting parameter usage, improving code clarity, and fixing argument passing in test cases.

**Test argument handling and command simulation:**

* Refactored test cases in `tests/test.py` to set the simulated command text (`m.data.text`) directly using the appropriate command word and arguments, instead of modifying the `always_argument` field in config objects. This change affects multiple cases including "summary", "graph", "graph_point", "graph_rank", "graph_statistics", "ranking", "report", "pdf", and "rating" to ensure more accurate and maintainable test simulations. [[1]](diffhunk://#diff-002b17638e4a840ab803fb150dddd393a637a14314ed5c395a048192850b2603L122-R122) [[2]](diffhunk://#diff-002b17638e4a840ab803fb150dddd393a637a14314ed5c395a048192850b2603L134-R134) [[3]](diffhunk://#diff-002b17638e4a840ab803fb150dddd393a637a14314ed5c395a048192850b2603L155-R170) [[4]](diffhunk://#diff-002b17638e4a840ab803fb150dddd393a637a14314ed5c395a048192850b2603L183-R183) [[5]](diffhunk://#diff-002b17638e4a840ab803fb150dddd393a637a14314ed5c395a048192850b2603L195-R195) [[6]](diffhunk://#diff-002b17638e4a840ab803fb150dddd393a637a14314ed5c395a048192850b2603L207-R207)

**SQL query corrections:**

* Fixed filtering logic in `record.info.sql` to use the correct column (`name` instead of `team`) when excluding unassigned teams and when filtering by player/team name, ensuring queries return the intended results.

**Plotting and display improvements:**

* Corrected the usage of the `legend` function in `stats_report.py` to use `labels` instead of `handles` for proper legend display in matplotlib plots.
* Fixed a variable reference in `api.py` to use `options.title` instead of `title` when printing `Path` objects, improving output consistency.