### PR TITLE
Add StyleOptions import and initialize in AdapterAPI post method for …

### DIFF
--- a/integrations/discord/api.py
+++ b/integrations/discord/api.py
@@ -16,6 +16,7 @@ from cls.timekit import Delimiter, Format
 from cls.timekit import ExtendedDatetime as ExtDt
 from integrations.base.interface import APIInterface
 from integrations.protocols import CommandType
+from libs.types import StyleOptions
 from libs.utils import converter, formatter, textutil
 
 sys.modules["audioop"] = _audioop
@@ -87,7 +88,6 @@ class AdapterAPI(APIInterface):
         # 見出しポスト
         header_title = ""
         header_text = ""
-
         if m.post.headline:
             header_title, header_text = next(iter(m.post.headline.items()))
             m.post.thread_title = header_title
@@ -102,6 +102,7 @@ class AdapterAPI(APIInterface):
             m.post.thread = True
 
         # 本文
+        options = StyleOptions()
         post_msg: list[str] = []
         for data, options in m.post.message:
             header = ""

--- a/integrations/slack/api.py
+++ b/integrations/slack/api.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 from integrations.base.interface import APIInterface
 from integrations.protocols import CommandType
+from libs.types import StyleOptions
 from libs.utils import converter, formatter
 
 if TYPE_CHECKING:
@@ -90,6 +91,7 @@ class AdapterAPI(APIInterface):
                 _post_header()
 
         # 本文
+        options = StyleOptions()
         post_msg: list[str] = []
         for data, options in m.post.message:
             header = ""


### PR DESCRIPTION
This pull request introduces minor updates to both the Discord and Slack integration APIs. The main change is the import and initialization of the `StyleOptions` type from `libs.types`, which is now used when processing post message content in both integrations.

- **Integration of StyleOptions for Message Formatting**
  - Both `integrations/discord/api.py` and `integrations/slack/api.py` now import `StyleOptions` from `libs.types`, and initialize an instance of `StyleOptions` before processing post messages. This prepares the codebase for more consistent or advanced message styling in the future. [[1]](diffhunk://#diff-e70f2c4ac2e5530abf5bae8dede764a1abe586aec1781fb4dd21c822d3828c7bR19) [[2]](diffhunk://#diff-c5bb1d09c9ee7902c6ccfdd9a3b6f9cea1101bc69fd2d9d6a4dd1caee050bb92R14) [[3]](diffhunk://#diff-e70f2c4ac2e5530abf5bae8dede764a1abe586aec1781fb4dd21c822d3828c7bR105) [[4]](diffhunk://#diff-c5bb1d09c9ee7902c6ccfdd9a3b6f9cea1101bc69fd2d9d6a4dd1caee050bb92R94)

Other minor adjustments include a small formatting change in the Discord integration's `_table_data` function, but there are no significant logic changes.…Discord and Slack integrations