### PR TITLE
Develop

### DIFF
--- a/integrations/slack/api.py
+++ b/integrations/slack/api.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, cast
 import pandas as pd
 
 from integrations.base.interface import APIInterface
-from integrations.protocols import CommandType
 from libs.types import StyleOptions
 from libs.utils import converter, formatter
 
@@ -52,17 +51,16 @@ class AdapterAPI(APIInterface):
                 return f"*【{title}】*\n"
             return ""
 
-        def _table_data(data: dict, codeblock: bool = True) -> list:
+        def _table_data(data: dict) -> list:
             ret_list: list = []
             text_data = iter(data.values())
-            symbol = "```\n" if codeblock else ""
             # 先頭ブロックの処理(ヘッダ追加)
             v = next(text_data)
 
-            ret_list.append(f"{header}{symbol}{v}\n{symbol}" if options.codeblock else f"{header}{v}\n")
+            ret_list.append(f"{header}```\n{v}\n```\n" if options.codeblock else f"{header}{v}\n")
             # 残りのブロック
             for v in text_data:
-                ret_list.append(f"{symbol}{v}\n{symbol}" if options.codeblock else f"{symbol}{v}\n{symbol}")
+                ret_list.append(f"```\n{v}\n```\n" if options.codeblock else f"{v}\n")
 
             return ret_list
 
@@ -110,38 +108,33 @@ class AdapterAPI(APIInterface):
             if isinstance(data, str):
                 if options.key_title and (options.title != header_title):
                     header = _header_text(options.title)
-                post_msg.append(f"{header}```\n{data.rstrip()}\n```\n" if options.codeblock else f"{header}{data.rstrip()}\n")
+                text_body = textwrap.indent(data.rstrip(), "\t" * options.indent)
+                post_msg.append(f"{header}```\n{text_body}\n```\n" if options.codeblock else f"{header}{text_body}\n")
 
             if isinstance(data, pd.DataFrame):
                 if options.key_title and (options.title != header_title):
                     header = _header_text(options.title)
-
-                match m.status.command_type:
-                    case CommandType.RESULTS:
-                        match options.title:
-                            case "通算ポイント" | "ポイント差分":
-                                post_msg.extend(_table_data(converter.df_to_text_table(formatter.df_rename(data, options), step=40)))
-                            case "役満和了" | "卓外清算" | "その他":
-                                if "回数" in data.columns:
-                                    post_msg.extend(_table_data(converter.df_to_count(formatter.df_rename(data, options), options.title, 1)))
-                                else:
-                                    post_msg.extend(_table_data(converter.df_to_remarks(formatter.df_rename(data, options))))
-                            case "成績詳細比較":
-                                post_msg.extend(_table_data(converter.df_to_text_table2(formatter.df_rename(data, options), options, 3800)))
-                            case "座席データ":
-                                post_msg.extend(_table_data(converter.df_to_seat_data(formatter.df_rename(data, options), 1)))
-                            case "戦績":
-                                if "東家 名前" in data.columns:  # 縦持ちデータ
-                                    options.summarize = False
-                                    post_msg.extend(_table_data(converter.df_to_results_details(formatter.df_rename(data, options)), False))
-                                else:
-                                    post_msg.extend(_table_data(converter.df_to_results_simple(formatter.df_rename(data, options))))
-                            case _:
-                                post_msg.extend(_table_data(converter.df_to_remarks(formatter.df_rename(data, options))))
-                    case CommandType.RATING:
-                        post_msg.extend(_table_data(converter.df_to_text_table(formatter.df_rename(data, options), step=20)))
-                    case CommandType.RANKING:
+                match options.data_kind:
+                    case StyleOptions.DataKind.POINTS_TOTAL | StyleOptions.DataKind.POINTS_DIFF:
+                        post_msg.extend(_table_data(converter.df_to_text_table(data, options, step=40)))
+                    case StyleOptions.DataKind.REMARKS_YAKUMAN | StyleOptions.DataKind.REMARKS_REGULATION | StyleOptions.DataKind.REMARKS_OTHER:
+                        options.indent = 1
+                        post_msg.extend(_table_data(converter.df_to_remarks(data, options)))
+                    case StyleOptions.DataKind.DETAILED_COMPARISON:
+                        post_msg.extend(_table_data(converter.df_to_text_table2(data, options, limit=3800)))
+                    case StyleOptions.DataKind.SEAT_DATA:
+                        options.indent = 1
+                        post_msg.extend(_table_data(converter.df_to_seat_data(data, options)))
+                    case StyleOptions.DataKind.RECORD_DATA:
+                        options.summarize = False
+                        post_msg.extend(_table_data(converter.df_to_results_simple(data, options, limit=2600)))
+                    case StyleOptions.DataKind.RECORD_DATA_ALL:
+                        options.summarize = False
+                        post_msg.extend(_table_data(converter.df_to_results_details(data, options, limit=2600)))
+                    case StyleOptions.DataKind.RANKING:
                         post_msg.extend(_table_data(converter.df_to_ranking(data, options.title, step=50)))
+                    case StyleOptions.DataKind.RATING:
+                        post_msg.extend(_table_data(converter.df_to_text_table(data, options, step=20)))
                     case _:
                         pass
 
@@ -149,11 +142,19 @@ class AdapterAPI(APIInterface):
             post_msg = formatter.group_strings(post_msg)
 
         for msg in post_msg:
-            self._call_chat_post_message(
-                channel=m.data.channel_id,
-                text=msg,
-                thread_ts=m.reply_ts,
-            )
+            if options.data_kind == StyleOptions.DataKind.RECORD_DATA:
+                self._call_chat_post_message(
+                    channel=m.data.channel_id,
+                    text=msg.rstrip(),
+                    blocks=[{"type": "section", "text": {"type": "mrkdwn", "text": msg.rstrip()}}],
+                    thread_ts=m.reply_ts,
+                )
+            else:
+                self._call_chat_post_message(
+                    channel=m.data.channel_id,
+                    text=msg.rstrip(),
+                    thread_ts=m.reply_ts,
+                )
 
     def _call_chat_post_message(self, **kwargs) -> "SlackResponse":
         """slackにメッセージをポストする

--- a/libs/commands/results/summary.py
+++ b/libs/commands/results/summary.py
@@ -25,7 +25,6 @@ def aggregation(m: "MessageParserProtocol"):
 
     # --- データ収集
     data: "MessageType"
-    options: StyleOptions
     game_info = GameInfo()
     df_summary = aggregate.game_summary()
     df_game = loader.read_data("SUMMARY_DETAILS")
@@ -86,7 +85,7 @@ def aggregation(m: "MessageParserProtocol"):
 
     if options.format_type == "default":
         options.codeblock = True
-        data = formatter.df_rename(df_summary.filter(items=header_list), options)
+        data = df_summary.filter(items=header_list)
     else:
         options.base_name = "summary"
         df_summary = df_summary.filter(items=filter_list).fillna("*****")
@@ -101,7 +100,7 @@ def aggregation(m: "MessageParserProtocol"):
 
         if options.format_type == "default":
             options.codeblock = False
-            data = formatter.df_rename(df_yakuman, options)
+            data = df_yakuman
         else:
             options.base_name = "yakuman"
             data = converter.save_output(df_yakuman, options, f"【役満和了】\n{header_text}", "yakuman")
@@ -120,7 +119,7 @@ def aggregation(m: "MessageParserProtocol"):
 
         if options.format_type == "default":
             options.codeblock = False
-            data = formatter.df_rename(df_regulations, options)
+            data = df_regulations
         else:
             options.base_name = "regulations"
             data = converter.save_output(df_regulations, options, f"【卓外清算】\n{header_text}", "regulations")
@@ -134,7 +133,7 @@ def aggregation(m: "MessageParserProtocol"):
         df_others = df_remarks.query("type == 1").drop(columns=["type", "ex_point"])
 
         if options.format_type == "default":
-            data = formatter.df_rename(df_others, options)
+            data = df_others
         else:
             options.base_name = "others"
             data = converter.save_output(df_others, options, f"【その他】\n{header_text}", "others")
@@ -200,6 +199,6 @@ def difference(m: "MessageParserProtocol"):
             data = converter.save_output(df_summary.filter(items=filter_list).fillna("*****"), options, f"【{headline_title}】\n{header_text}")
         case _:
             options.format_type = "default"
-            data = formatter.df_rename(df_summary.filter(items=header_list), options)
+            data = df_summary.filter(items=header_list)
 
     m.set_data(data, StyleOptions(**options.asdict))

--- a/libs/types.py
+++ b/libs/types.py
@@ -112,6 +112,8 @@ class StyleOptions:
         """座席データ"""
         RECORD_DATA = auto()
         """戦績データ"""
+        RECORD_DATA_ALL = auto()
+        """戦績データ(全体)"""
         RANKING = auto()
         """ランキングデータ"""
         RATING = auto()

--- a/libs/utils/formatter.py
+++ b/libs/utils/formatter.py
@@ -340,6 +340,8 @@ def df_rename(df: pd.DataFrame, options: StyleOptions) -> pd.DataFrame:
         # メモ
         "regulation": "卓外清算",
         "remarks": "メモ",
+        #
+        "memo": "備考",
     }
 
     match options.rename_type:


### PR DESCRIPTION
This pull request refactors how data is processed and formatted for Slack and Discord integrations, focusing on unifying and simplifying the handling of different data types and output formats. The main changes include introducing a new `data_kind` field in `StyleOptions` to standardize data flow, centralizing DataFrame formatting logic, and improving message output consistency. These changes make the codebase more maintainable and extensible for future data types and output requirements.

**Refactoring and Standardization of Data Handling:**

* Introduced and propagated the `data_kind` field in `StyleOptions`, allowing downstream functions to select formatting logic based on data type rather than relying on command type or title string matching. This affects both the Slack and Discord integrations and the command processing logic. [[1]](diffhunk://#diff-1e42f0ec2db60cad05bf4dc95600dcc1a0004873c61af2466f9d8b2f7054c827L134-R136) [[2]](diffhunk://#diff-1e42f0ec2db60cad05bf4dc95600dcc1a0004873c61af2466f9d8b2f7054c827L146-R168) [[3]](diffhunk://#diff-1e42f0ec2db60cad05bf4dc95600dcc1a0004873c61af2466f9d8b2f7054c827R235) [[4]](diffhunk://#diff-c49f36eea9710317471ae3d9851d4a34f9f138d796ca97089d914a2c1a8259a4R115-R116) [[5]](diffhunk://#diff-e70f2c4ac2e5530abf5bae8dede764a1abe586aec1781fb4dd21c822d3828c7bL121-R146) [[6]](diffhunk://#diff-c5bb1d09c9ee7902c6ccfdd9a3b6f9cea1101bc69fd2d9d6a4dd1caee050bb92L113-R155)

* Centralized DataFrame renaming and formatting: Instead of pre-formatting DataFrames before passing to output functions, the formatting (such as with `formatter.df_rename`) is now handled within the output conversion utilities (e.g., `df_to_text_table`). This reduces redundancy and potential inconsistencies in data formatting. [[1]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eL89-R88) [[2]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eL104-R103) [[3]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eL123-R122) [[4]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eL137-R136) [[5]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eL203-R202) [[6]](diffhunk://#diff-057ee2ac5fb9c50aeb703d0425f30a8a05e60e9aede89fa1d691a01c35fa9d25L78-R95)

**Improvements to Output Formatting and Indentation:**

* Improved code block and indentation handling for both Slack and Discord outputs, ensuring consistent formatting and easier-to-read messages. Indentation is now controlled by the `indent` option, and code block formatting is applied more systematically. [[1]](diffhunk://#diff-e70f2c4ac2e5530abf5bae8dede764a1abe586aec1781fb4dd21c822d3828c7bL71-R80) [[2]](diffhunk://#diff-c5bb1d09c9ee7902c6ccfdd9a3b6f9cea1101bc69fd2d9d6a4dd1caee050bb92L55-R63) [[3]](diffhunk://#diff-c5bb1d09c9ee7902c6ccfdd9a3b6f9cea1101bc69fd2d9d6a4dd1caee050bb92L113-R155) [[4]](diffhunk://#diff-1e42f0ec2db60cad05bf4dc95600dcc1a0004873c61af2466f9d8b2f7054c827L134-R136)

**Data Structure and Naming Consistency:**

* Standardized column naming in DataFrames, replacing the Japanese "備考" with the English "memo" for consistency and easier downstream processing. [[1]](diffhunk://#diff-1e42f0ec2db60cad05bf4dc95600dcc1a0004873c61af2466f9d8b2f7054c827L340-R345) [[2]](diffhunk://#diff-1e42f0ec2db60cad05bf4dc95600dcc1a0004873c61af2466f9d8b2f7054c827L389-R394)

**Minor Cleanups:**

* Removed unused imports and variables, such as `CommandType` and redundant local variables, to streamline the code. [[1]](diffhunk://#diff-c5bb1d09c9ee7902c6ccfdd9a3b6f9cea1101bc69fd2d9d6a4dd1caee050bb92L13) [[2]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eL28)

These changes collectively make the integrations more robust, easier to extend, and less error-prone by centralizing logic and reducing reliance on fragile string matching.