### PR TITLE
Refactor data handling in detail, ranking, and report modules for imp…

### DIFF
--- a/integrations/web/events/create_bp/detail.py
+++ b/integrations/web/events/create_bp/detail.py
@@ -77,17 +77,7 @@ def _conv_verbose(df: pd.DataFrame) -> pd.DataFrame:
     """
 
     if not isinstance(df.columns, pd.MultiIndex):
-        if not g.params.get("individual", True):  # チーム戦
-            df.rename(
-                columns={
-                    "東家 名前": "東家 チーム",
-                    "南家 名前": "南家 チーム",
-                    "西家 名前": "西家 チーム",
-                    "北家 名前": "北家 チーム",
-                },
-                inplace=True,
-            )
-        new_columns = [tuple(col.split(" ")) if " " in col else ("", col) for col in df.columns]
+        new_columns = [tuple(col.split("_")) if len(col.split("_")) != 1 else ("", col) for col in df.columns]
         df.columns = pd.MultiIndex.from_tuples(new_columns, names=["座席", "項目"])
 
     return df

--- a/integrations/web/events/create_bp/ranking.py
+++ b/integrations/web/events/create_bp/ranking.py
@@ -10,8 +10,6 @@ from flask import Blueprint, abort, current_app, request
 
 import libs.dispatcher
 import libs.global_value as g
-from libs.types import StyleOptions
-from libs.utils import formatter
 
 if TYPE_CHECKING:
     from integrations.web.adapter import ServiceAdapter
@@ -50,9 +48,7 @@ def ranking_bp(adapter: "ServiceAdapter") -> Blueprint:
 
             if isinstance(data, pd.DataFrame):
                 show_index = options.show_index
-                message += adapter.functions.to_styled_html(
-                    formatter.df_rename(data, StyleOptions(rename_type=StyleOptions.RenameType.NORMAL)), padding, show_index
-                )
+                message += adapter.functions.to_styled_html(data, padding, show_index)
 
             if isinstance(data, str):
                 message += adapter.functions.to_text_html(data)

--- a/integrations/web/events/create_bp/report.py
+++ b/integrations/web/events/create_bp/report.py
@@ -47,7 +47,6 @@ def report_bp(adapter: "ServiceAdapter") -> Blueprint:
                 message += f"<h2>{options.title}</h2>\n"
 
             if isinstance(data, pd.DataFrame):
-                print(data)
                 show_index = options.show_index
                 if {"個人成績一覧", "チーム成績一覧"} & set(m.post.headline):
                     check_column = data.columns.to_list()

--- a/integrations/web/functions.py
+++ b/integrations/web/functions.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 from flask import make_response, render_template
 
 from integrations.base.interface import FunctionsInterface
+from libs.types import StyleOptions
+from libs.utils import formatter
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -31,6 +33,8 @@ class SvcFunctions(FunctionsInterface):
             str: HTML表
         """
 
+        df = formatter.df_rename(df, StyleOptions(rename_type=StyleOptions.RenameType.NORMAL))
+        df = df.rename(columns={"name": "プレイヤー名", "point": "ポイント", "rank": "順位"}).copy()
         styled = (
             df.style.format(
                 {

--- a/libs/utils/formatter.py
+++ b/libs/utils/formatter.py
@@ -227,6 +227,12 @@ def df_rename(df: pd.DataFrame, options: StyleOptions) -> pd.DataFrame:
     """
 
     rename_dict: dict = {
+        #
+        "p1": "東家",
+        "p2": "南家",
+        "p3": "西家",
+        "p4": "北家",
+        #
         "playtime": "日時",
         "rate": "レート",
         "participation_rate": "ゲーム参加率",


### PR DESCRIPTION
This pull request refactors how DataFrames are renamed and displayed in the web event reporting and ranking features. The main change is to centralize and standardize the column renaming logic using the `formatter.df_rename` utility, improving code maintainability and consistency across the application. Additionally, some redundant code and imports have been cleaned up.

**Standardization and Centralization of DataFrame Renaming:**

* The column renaming logic for DataFrames is now handled by `formatter.df_rename` with `StyleOptions`, ensuring consistent naming conventions throughout the application. This is applied in `to_styled_html` in `integrations/web/functions.py` and the renaming dictionary in `libs/utils/formatter.py` has been expanded to include seat names (`p1`, `p2`, etc.). [[1]](diffhunk://#diff-cbf903373b29862e0b237803ddfb76e64e43b7a7885bb0348681081f6850936fR36-R37) [[2]](diffhunk://#diff-22dae28220e49d4f2e9c0f814cfb2b2ce2b4fdb354d38da9b25e5a664b7552ffR230-R235)

* The renaming of columns in `_conv_verbose` in `detail.py` is now based on splitting by underscores instead of spaces, which standardizes column handling and removes previous team-based renaming logic.

**Code Cleanup and Refactoring:**

* Unused imports (`StyleOptions` and `formatter`) have been removed from `ranking.py`, and their usage has been shifted to where they are actually needed.

* The DataFrame renaming step in `ranking.py` has been removed since it is now handled in `to_styled_html`, simplifying the code and reducing redundancy.

* A debug print statement has been removed from the `report` function in `report.py` for cleaner output.…roved clarity and consistency