### PR TITLE
Develop

### DIFF
--- a/cls/stats.py
+++ b/cls/stats.py
@@ -460,7 +460,7 @@ class StatsInfo:
 
     @property
     def yakuman_list(self) -> list:
-        """ "座席別役満和了率"""
+        """座席別役満和了率"""
 
         return [
             self.seat1.yakuman,


### PR DESCRIPTION
This pull request improves the robustness and clarity of the result comparison logic in `libs/commands/results/detail.py`, ensuring that empty or missing data is handled gracefully. It also includes a minor docstring formatting fix in `cls/stats.py`.

Error handling and result reporting improvements:

* Added checks in `comparison` to ensure that if `game_info.count` is zero or missing, or if the constructed `stats_df` is empty, the code sets an appropriate headline message and marks the result as failed, preventing further processing. [[1]](diffhunk://#diff-1e42f0ec2db60cad05bf4dc95600dcc1a0004873c61af2466f9d8b2f7054c827L197-R206) [[2]](diffhunk://#diff-1e42f0ec2db60cad05bf4dc95600dcc1a0004873c61af2466f9d8b2f7054c827R216-L219)

Minor formatting fix:

* Removed an extraneous space from the docstring in `yakuman_list` property in `cls/stats.py`.