### PR TITLE
Develop

### DIFF
--- a/integrations/slack/api.py
+++ b/integrations/slack/api.py
@@ -91,6 +91,7 @@ class AdapterAPI(APIInterface):
         # 本文
         options = StyleOptions()
         post_msg: list[str] = []
+        block_layout = False
         for data, options in m.post.message:
             header = ""
 
@@ -126,10 +127,9 @@ class AdapterAPI(APIInterface):
                         options.indent = 1
                         post_msg.extend(_table_data(converter.df_to_seat_data(data, options)))
                     case StyleOptions.DataKind.RECORD_DATA:
-                        options.summarize = False
-                        post_msg.extend(_table_data(converter.df_to_results_simple(data, options, limit=2600)))
+                        block_layout = True
+                        post_msg.extend(_table_data(converter.df_to_results_simple(data, options, limit=1900)))
                     case StyleOptions.DataKind.RECORD_DATA_ALL:
-                        options.summarize = False
                         post_msg.extend(_table_data(converter.df_to_results_details(data, options, limit=2600)))
                     case StyleOptions.DataKind.RANKING:
                         post_msg.extend(_table_data(converter.df_to_ranking(data, options.title, step=50)))
@@ -142,7 +142,8 @@ class AdapterAPI(APIInterface):
             post_msg = formatter.group_strings(post_msg)
 
         for msg in post_msg:
-            if options.data_kind == StyleOptions.DataKind.RECORD_DATA:
+            if msg != msg.lstrip() or (not msg.find("*【戦績】*") and block_layout):
+                print(msg)
                 self._call_chat_post_message(
                     channel=m.data.channel_id,
                     text=msg.rstrip(),

--- a/integrations/slack/api.py
+++ b/integrations/slack/api.py
@@ -143,7 +143,6 @@ class AdapterAPI(APIInterface):
 
         for msg in post_msg:
             if msg != msg.lstrip() or (not msg.find("*【戦績】*") and block_layout):
-                print(msg)
                 self._call_chat_post_message(
                     channel=m.data.channel_id,
                     text=msg.rstrip(),

--- a/libs/commands/graph/summary.py
+++ b/libs/commands/graph/summary.py
@@ -399,6 +399,8 @@ def _graph_title(graph_params: GraphParams):
                 graph_params.update({"title_text": f"順位変動 (直近 {g.params['target_count']} ゲーム)"})
             case "point_hbar":
                 graph_params.update({"title_text": f"通算ポイント (直近 {g.params['target_count']} ゲーム)"})
+            case _:
+                raise ValueError("Unsupported")
     else:
         match g.params.get("collection"):
             case "daily":

--- a/libs/commands/results/detail.py
+++ b/libs/commands/results/detail.py
@@ -156,16 +156,16 @@ def aggregation(m: "MessageParserProtocol"):
         work_df = count_df.query("type == 1").filter(items=["matter", "matter_count"])
         m.set_data(work_df, StyleOptions(title="その他", data_kind=StyleOptions.DataKind.REMARKS_OTHER))
 
+    # 対戦結果
+    if g.params.get("versus_matrix"):
+        m.set_data(get_versus_matrix(mapping_dict), StyleOptions(title="対戦結果", indent=1))
+
     # 戦績
     if g.params.get("game_results"):
         if g.params.get("verbose"):
             m.set_data(get_results_details(mapping_dict), StyleOptions(title="戦績", data_kind=StyleOptions.DataKind.RECORD_DATA_ALL, codeblock=False))
         else:
             m.set_data(get_results_simple(mapping_dict), StyleOptions(title="戦績", data_kind=StyleOptions.DataKind.RECORD_DATA, codeblock=False))
-
-    # 対戦結果
-    if g.params.get("versus_matrix"):
-        m.set_data(get_versus_matrix(mapping_dict), StyleOptions(title="対戦結果", indent=1))
 
     # 非表示項目を除外
     m.post.message = [(data, options) for data, options in m.post.message if options.title not in g.cfg.dropitems.results]

--- a/libs/types.py
+++ b/libs/types.py
@@ -111,9 +111,9 @@ class StyleOptions:
         SEAT_DATA = auto()
         """座席データ"""
         RECORD_DATA = auto()
-        """戦績データ"""
+        """戦績データ(簡易版)"""
         RECORD_DATA_ALL = auto()
-        """戦績データ(全体)"""
+        """戦績データ(詳細版)"""
         RANKING = auto()
         """ランキングデータ"""
         RATING = auto()

--- a/libs/utils/dbutil.py
+++ b/libs/utils/dbutil.py
@@ -223,6 +223,8 @@ def query_modification(sql: str) -> str:
         case "A":
             sql = sql.replace("<<collection>>", "'合計' as 集計")
             sql = sql.replace("<<group by>>", "")
+        case _:
+            raise ValueError("Unsupported")
 
     if g.params.get("interval") is not None:
         if g.params.get("interval") == 0:

--- a/libs/utils/formatter.py
+++ b/libs/utils/formatter.py
@@ -476,9 +476,9 @@ def group_strings(lines: list[str], limit: int = 3000) -> list[str]:
     if buffer:
         result.append("\n".join(buffer))
 
-    # コードブロックの連結
-    # result = [str(x).replace("\n```\n\n```\n", "\n") for x in result]
+    # 改行の集約
     result = [str(x).replace("\n```\n\n```\n", "\n```\n```\n") for x in result]
+    result = [str(x).replace("\n\n\t", "\n\t") for x in result]
 
     return result
 


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to data formatting, error handling, and Slack message posting logic. The main themes are enhanced error checking, message formatting adjustments, and minor refactoring for clarity.

**Error Handling Improvements:**
- Added explicit error raising for unsupported cases in both the `_graph_title` function (`libs/commands/graph/summary.py`) and the `query_modification` function (`libs/utils/dbutil.py`). This ensures that unexpected input is caught early and handled properly. [[1]](diffhunk://#diff-3d3413024488da3c96079d9224c26d78f8794488591e783b405b376ba0a45ccbR402-R403) [[2]](diffhunk://#diff-607db1fd99722303e6e8187148735bea4468fbe99ec869f1893ca2e3e57e49b8R226-R227)

**Slack Message Formatting and Posting:**
- Adjusted the logic in `_post_header` (`integrations/slack/api.py`) to introduce a `block_layout` flag for better control over message formatting, especially for record data. Also, reduced the data limit for simple record data from 2600 to 1900 and updated the message posting condition to rely on the new flag and message content. [[1]](diffhunk://#diff-c5bb1d09c9ee7902c6ccfdd9a3b6f9cea1101bc69fd2d9d6a4dd1caee050bb92R94) [[2]](diffhunk://#diff-c5bb1d09c9ee7902c6ccfdd9a3b6f9cea1101bc69fd2d9d6a4dd1caee050bb92L129-L132) [[3]](diffhunk://#diff-c5bb1d09c9ee7902c6ccfdd9a3b6f9cea1101bc69fd2d9d6a4dd1caee050bb92L145-R145)

**Data and Style Option Clarifications:**
- Updated the descriptions for `RECORD_DATA` and `RECORD_DATA_ALL` in the `DataKind` enum to clarify that they represent the simple and detailed versions of the record data, respectively.

**Formatting Utilities:**
- Improved the `group_strings` function in `libs/utils/formatter.py` to better handle newlines and indentation, ensuring messages are more readable when posted.

**Minor Refactoring:**
- Reordered the addition of "対戦結果" (versus matrix) data in `aggregation` to appear before "戦績" (game results), making the logic clearer and possibly affecting the output order.