### PR TITLE
Develop

### DIFF
--- a/cls/command.py
+++ b/cls/command.py
@@ -13,7 +13,9 @@ from cls.timekit import ExtendedDatetime as ExtDt
 from libs.utils import formatter, textutil
 
 CommandResult = Mapping[str, Union[str, int, bool, tuple[str, ...]]]
+"""コマンド処理結果の型（パラメータ名とその値のマッピング）"""
 CommandAction = Callable[[Union[str, tuple[str, ...]]], CommandResult]
+"""コマンド処理関数の型（入力文字列を受け取り、結果辞書を返す）"""
 
 
 class CommandSpec(TypedDict, total=False):

--- a/cls/command.py
+++ b/cls/command.py
@@ -28,18 +28,16 @@ class CommandSpec(TypedDict, total=False):
 
 CommandsDict = dict[str, CommandSpec]
 COMMANDS: CommandsDict = {
-    "guest": {
-        "match": [r"^ゲストナシ$", r"^ゲストアリ$", r"^ゲスト無効$"],
-        "action": lambda w: {
-            "ゲストナシ": {"guest_skip": False, "guest_skip2": False, "unregistered_replace": True},
-            "ゲストアリ": {"guest_skip": True, "guest_skip2": True, "unregistered_replace": True},
-            "ゲスト無効": {"unregistered_replace": False},
-        }[w[0] if isinstance(w, tuple) else w],
+    # --- ゲスト処理
+    "guest_off": {
+        "match": [r"^ゲストナシ$"],
+        "action": lambda _: {"guest_skip": False, "guest_skip2": False, "unregistered_replace": True},
     },
-    "anonymous": {
-        "match": [r"^匿名$", r"^anonymous$"],
-        "action": lambda _: {"anonymous": True},
+    "guest_on": {
+        "match": [r"^ゲストアリ$"],
+        "action": lambda _: {"guest_skip": True, "guest_skip2": True, "unregistered_replace": True},
     },
+    # --- 個人戦/チーム戦
     "individual": {
         "match": [r"^個人$", "^個人成績$"],
         "action": lambda _: {"individual": True},
@@ -59,6 +57,15 @@ COMMANDS: CommandsDict = {
     "b": {
         "match": [r"^(チーム同卓ナシ|コンビナシ)$"],
         "action": lambda _: {"friendly_fire": False},
+    },
+    # --- プレイヤー名変換処理
+    "guest_disable": {
+        "match": [r"^ゲスト無効$"],
+        "action": lambda _: {"unregistered_replace": False},
+    },
+    "anonymous": {
+        "match": [r"^匿名$", r"^anonymous$"],
+        "action": lambda _: {"anonymous": True},
     },
     # --- 動作変更フラグ
     "score_comparisons": {  # 比較

--- a/cls/score.py
+++ b/cls/score.py
@@ -19,9 +19,9 @@ class Score:
     name: str = field(default="")
     """プレイヤー名"""
     r_str: str = field(default="")
-    """入力された素点情報(文字列)"""
+    """素点(ユーザー入力文字列/未計算)"""
     rpoint: int = field(default=0)
-    """素点(入力文字列評価後)"""
+    """素点(ユーザー入力文字列評価後)"""
     point: float = field(default=0.0)
     """獲得ポイント"""
     rank: int = field(default=0)

--- a/cls/score.py
+++ b/cls/score.py
@@ -14,7 +14,13 @@ if TYPE_CHECKING:
 
 @dataclass
 class Score:
-    """プレイヤー成績"""
+    """プレイヤー成績
+
+    Note:
+        フィールド名の 'r_' プレフィックス (r_str, rpoint など) は、
+        GameResult.to_dict() によって 'p1_', 'p2_', 'p3_', 'p4_' に置換され、
+        DBテーブルのカラム名 (p1_str, p2_str など) として使用する。
+    """
 
     name: str = field(default="")
     """プレイヤー名"""
@@ -35,10 +41,14 @@ class Score:
         """データを辞書で返す
 
         Args:
-            prefix (str): キーに付与する接頭辞
+            prefix (str): キーに付与する接頭辞 (p1, p2, p3, p4)
 
         Returns:
             ScoreDict: 返却する辞書
+
+        Note:
+            フィールド名の 'r_' プレフィックスは、指定された prefix に置換される。
+            例: r_str -> p1_str (prefix='p1' の場合)
         """
 
         return cast(

--- a/libs/datamodels.py
+++ b/libs/datamodels.py
@@ -55,11 +55,11 @@ class GameInfo:
             self.first_comment = ""
             self.last_comment = ""
         else:
-            self.count = int(df["count"].to_string(index=False))
-            self.first_game = ExtDt(df["first_game"].to_string(index=False))
-            self.last_game = ExtDt(df["last_game"].to_string(index=False))
-            self.first_comment = str(df["first_comment"].to_string(index=False))
-            self.last_comment = str(df["last_comment"].to_string(index=False))
+            self.count = int(df["count"].iloc[0])
+            self.first_game = ExtDt(str(df["first_game"].iloc[0]))
+            self.last_game = ExtDt(str(df["last_game"].iloc[0]))
+            self.first_comment = str(df["first_comment"].iloc[0])
+            self.last_comment = str(df["last_comment"].iloc[0])
 
         # 規定打数更新
         if not g.params.get("stipulated", 0):  # 規定打数0はレートから計算

--- a/libs/datamodels.py
+++ b/libs/datamodels.py
@@ -72,6 +72,8 @@ class GameInfo:
                     g.params["stipulated"] = g.cfg.ranking.stipulated_calculation(self.count)
                 case "report":
                     g.params["stipulated"] = g.cfg.report.stipulated_calculation(self.count)
+                case _:
+                    pass
 
         logging.debug(self)
 

--- a/libs/dispatcher.py
+++ b/libs/dispatcher.py
@@ -92,8 +92,8 @@ def other_words(word: str, m: "MessageParserProtocol"):
         if lookup.exsist_record(m.data.thread_ts).has_valid_data():
             modify.check_remarks(m)
     else:  # スコア登録
-        if score_dict := validator.check_score(m):  # 結果報告フォーマットに一致するポストの処理
-            score = GameResult(**score_dict)
+        if detection_dict := validator.check_score(m):  # 結果報告フォーマットに一致するポストの処理
+            score = GameResult(**detection_dict)
             # 名前ブレ修正
             for k, p in score.to_dict().items():
                 if k.endswith("_name"):

--- a/libs/dispatcher.py
+++ b/libs/dispatcher.py
@@ -136,25 +136,32 @@ def message_changed(detection: GameResult, m: "MessageParserProtocol"):
         detection (GameResult): スコアデータ
         m (MessageParserProtocol): メッセージデータ
     """
-
     record_data = lookup.exsist_record(m.data.event_ts)
 
-    if detection.to_dict() == record_data.to_dict():  # スコア比較
-        return  # 変更箇所がなければ何もしない
+    # 変更がない場合は終了
+    if detection.to_dict() == record_data.to_dict():
+        return
 
-    if _thread_check(m):
-        if record_data.has_valid_data():
-            if record_data.rule_version == g.cfg.mahjong.rule_version:
-                modify.db_update(detection, m)
-            else:
-                logging.debug("skip (rule_version not match). event_ts=%s", m.data.event_ts)
-        else:
-            modify.db_insert(detection, m)
-            modify.reprocessing_remarks(m)
-    else:
+    # スレッド内チェック → 処理対象外なら終了
+    if not _thread_check(m):
         m.post.ts = m.data.event_ts
         m.set_data(message.random_reply(m, "inside_thread"), StyleOptions(key_title=False))
         logging.debug("skip (inside thread). event_ts=%s, thread_ts=%s", m.data.event_ts, m.data.thread_ts)
+        return
+
+    # 既存データなし → 新規挿入
+    if not record_data.has_valid_data():
+        modify.db_insert(detection, m)
+        modify.reprocessing_remarks(m)
+        return
+
+    # rule_version不一致 → スキップ
+    if record_data.rule_version != g.cfg.mahjong.rule_version:
+        logging.debug("skip (rule_version mismatch). event_ts=%s", m.data.event_ts)
+        return
+
+    # 全条件クリア → 更新実行
+    modify.db_update(detection, m)
 
 
 def message_deleted(m: "MessageParserProtocol"):

--- a/libs/dispatcher.py
+++ b/libs/dispatcher.py
@@ -92,8 +92,8 @@ def other_words(word: str, m: "MessageParserProtocol"):
         if lookup.exsist_record(m.data.thread_ts).has_valid_data():
             modify.check_remarks(m)
     else:  # スコア登録
-        if detection := validator.check_score(m):  # 結果報告フォーマットに一致するポストの処理
-            score = GameResult(**detection)
+        if score_dict := validator.check_score(m):  # 結果報告フォーマットに一致するポストの処理
+            score = GameResult(**score_dict)
             # 名前ブレ修正
             for k, p in score.to_dict().items():
                 if k.endswith("_name"):
@@ -141,6 +141,7 @@ def message_changed(detection: GameResult, m: "MessageParserProtocol"):
 
     if detection.to_dict() == record_data.to_dict():  # スコア比較
         return  # 変更箇所がなければ何もしない
+
     if _thread_check(m):
         if record_data.has_valid_data():
             if record_data.rule_version == g.cfg.mahjong.rule_version:

--- a/libs/utils/formatter.py
+++ b/libs/utils/formatter.py
@@ -130,13 +130,13 @@ def name_replace(target: str, add_mark: bool = False, not_replace: bool = False)
 
     chk_pattern = [
         target,  # 無加工
-        textutil.str_conv(target, textutil.ConversionType.HtoZ),  # 半角数字 -> 全角数字
-        textutil.str_conv(target, textutil.ConversionType.KtoH),  # カタカナ -> ひらがな
-        textutil.str_conv(target, textutil.ConversionType.HtoK),  # ひらがな -> カタカナ
+        textutil.str_conv(target, textutil.ConversionType.HtoZ),  # 半角 -> 全角
+        textutil.str_conv(target, textutil.ConversionType.KtoH),  # カタ -> ひら
+        textutil.str_conv(target, textutil.ConversionType.HtoK),  # ひら -> カタ
         honor_remove(target),  # 敬称削除
-        honor_remove(textutil.str_conv(target, textutil.ConversionType.HtoZ)),
-        honor_remove(textutil.str_conv(target, textutil.ConversionType.KtoH)),
-        honor_remove(textutil.str_conv(target, textutil.ConversionType.HtoK)),
+        honor_remove(textutil.str_conv(target, textutil.ConversionType.HtoZ)),  # 敬称削除 + 半角 -> 全角
+        honor_remove(textutil.str_conv(target, textutil.ConversionType.KtoH)),  # 敬称削除 + カタ -> ひら
+        honor_remove(textutil.str_conv(target, textutil.ConversionType.HtoK)),  # 敬称削除 + カタ -> ひら
     ]
     chk_pattern = sorted(set(chk_pattern), key=chk_pattern.index)  # 順序を維持したまま重複排除
 

--- a/libs/utils/formatter.py
+++ b/libs/utils/formatter.py
@@ -102,11 +102,11 @@ def column_alignment(df: pd.DataFrame, header: bool = False, index: bool = False
             match x:
                 case "ゲーム数":
                     fmt.append("right")
-                case "通算" | "平均" | "1位" | "2位" | "3位" | "4位" | " 平順" | "トビ":
+                case "通算" | "平均" | "順位差" | "トップ差":
                     fmt.append("right")
-                case "通算" | "順位差" | "トップ差":
+                case "1位" | "2位" | "3位" | "4位" | "トビ":
                     fmt.append("right")
-                case "レート" | "平均順位" | "順位偏差" | "平均素点" | "得点偏差":
+                case "レート" | "平均順位" | "平順" | "順位偏差" | "平均素点" | "得点偏差":
                     fmt.append("right")
                 case _:
                     fmt.append("left")


### PR DESCRIPTION
This pull request refactors command handling, improves data processing logic, and enhances code documentation and clarity throughout the codebase. The most important changes include splitting and clarifying command definitions, improving score and record data handling, and updating documentation for better maintainability.

**Command handling refactor:**

* Split the original `"guest"` command into three distinct commands: `"guest_off"`, `"guest_on"`, and `"guest_disable"`, each with clearer matching patterns and actions. This makes command logic more explicit and maintainable. [[1]](diffhunk://#diff-9c8cf218acc4134b52e9d943b6fc62c2369436d6eba540ef910a92cc1172400fL29-R40) [[2]](diffhunk://#diff-9c8cf218acc4134b52e9d943b6fc62c2369436d6eba540ef910a92cc1172400fR61-R69)
* Added Japanese docstrings to the type definitions `CommandResult` and `CommandAction` in `command.py` for better code clarity.

**Score and record data handling improvements:**

* Updated the `Score` class docstring and field descriptions to clarify the meaning and usage of the `r_` prefix, explaining its transformation for database storage. Also improved documentation for the `to_dict` method to specify how field prefixes are replaced. [[1]](diffhunk://#diff-022e6a1183a8e9c917e0f904551b219f95f347aade06b52f30fbf0f7d067b509L17-R30) [[2]](diffhunk://#diff-022e6a1183a8e9c917e0f904551b219f95f347aade06b52f30fbf0f7d067b509L38-R51)
* Changed DataFrame value extraction in `libs/datamodels.py:get()` from `.to_string(index=False)` to `.iloc[0]` for more reliable and readable data access. Added a default case to the stipulated calculation logic for robustness. [[1]](diffhunk://#diff-a641d02a5298e4a63d02744c0e7b131d56acec994ac153f7c7e3af87cf52b46fL58-R62) [[2]](diffhunk://#diff-a641d02a5298e4a63d02744c0e7b131d56acec994ac153f7c7e3af87cf52b46fR75-R76)

**Dispatcher and utility logic updates:**

* Refactored score validation and update logic in `libs/dispatcher.py` to use clearer variable names and streamline the update flow, including more explicit branching for thread checks, rule version mismatches, and new record insertions. [[1]](diffhunk://#diff-f7f2d5ef6441ca6bd83fb6b712c662c54bbab01a8f8dd2c6e9aa04e5a8082609L95-R96) [[2]](diffhunk://#diff-f7f2d5ef6441ca6bd83fb6b712c662c54bbab01a8f8dd2c6e9aa04e5a8082609L139-R164)
* Improved column alignment logic in `formatter.py` to handle additional cases for right alignment, and updated comments in `name_replace` for clarity on conversion types. [[1]](diffhunk://#diff-22dae28220e49d4f2e9c0f814cfb2b2ce2b4fdb354d38da9b25e5a664b7552ffL105-R109) [[2]](diffhunk://#diff-22dae28220e49d4f2e9c0f814cfb2b2ce2b4fdb354d38da9b25e5a664b7552ffL133-R139)