### PR TITLE
Develop

### DIFF
--- a/integrations/base/interface.py
+++ b/integrations/base/interface.py
@@ -169,7 +169,6 @@ class MessageParserDataMixin:
         """メッセージデータをセット
 
         Args:
-            title (str): データ識別子
             data (MessageType): 内容
             options (StyleOptions): 表示オプション
         """

--- a/integrations/base/interface.py
+++ b/integrations/base/interface.py
@@ -11,12 +11,10 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, Optional, Type, TypeVar
 
 import pandas as pd
 
-from integrations.protocols import MsgData, PostData, StatusData
-
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from integrations.protocols import MessageParserProtocol
+    from integrations.protocols import MessageParserProtocol, MsgData, PostData, StatusData
     from libs.types import MessageType, StyleOptions
 
 ConfigT = TypeVar("ConfigT", bound="IntegrationsConfig")

--- a/integrations/base/interface.py
+++ b/integrations/base/interface.py
@@ -12,13 +12,12 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, Optional, Type, TypeVar
 import pandas as pd
 
 from integrations.protocols import MsgData, PostData, StatusData
-from libs.types import StyleOptions
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from integrations.protocols import MessageParserProtocol
-    from libs.types import MessageType
+    from libs.types import MessageType, StyleOptions
 
 ConfigT = TypeVar("ConfigT", bound="IntegrationsConfig")
 ApiT = TypeVar("ApiT", bound="APIInterface")
@@ -164,7 +163,7 @@ class MessageParserDataMixin:
     def set_data(
         self,
         data: "MessageType",
-        options: StyleOptions,
+        options: "StyleOptions",
     ):
         """メッセージデータをセット
 

--- a/integrations/protocols.py
+++ b/integrations/protocols.py
@@ -124,7 +124,7 @@ class PostData(DataMixin):
     """ヘッダ文"""
     message: list[tuple["MessageType", "StyleOptions"]] = field(default_factory=list)
     """本文
-    識別子(タイトルなど)をキーにした辞書型
+    MessageTypeとStyleOptionsのペアのリスト
     """
     thread: bool = field(default=True)
     """スレッドに返す"""

--- a/libs/types.py
+++ b/libs/types.py
@@ -173,7 +173,7 @@ class StyleOptions:
     - *False*: 削除する
     """
     transpose: bool = False
-    """The transpose of the DataFrame"""
+    """MessageTypeがDataFrameのとき表の縦横を変換する"""
     rename_type: RenameType = field(default=RenameType.NORMAL)
     """カラム名変換パラメータ"""
     data_kind: DataKind = field(default=DataKind.GENERAL)

--- a/libs/utils/formatter.py
+++ b/libs/utils/formatter.py
@@ -136,7 +136,7 @@ def name_replace(target: str, add_mark: bool = False, not_replace: bool = False)
         honor_remove(target),  # 敬称削除
         honor_remove(textutil.str_conv(target, textutil.ConversionType.HtoZ)),  # 敬称削除 + 半角 -> 全角
         honor_remove(textutil.str_conv(target, textutil.ConversionType.KtoH)),  # 敬称削除 + カタ -> ひら
-        honor_remove(textutil.str_conv(target, textutil.ConversionType.HtoK)),  # 敬称削除 + カタ -> ひら
+        honor_remove(textutil.str_conv(target, textutil.ConversionType.HtoK)),  # 敬称削除 + ひら -> カタ
     ]
     chk_pattern = sorted(set(chk_pattern), key=chk_pattern.index)  # 順序を維持したまま重複排除
 


### PR DESCRIPTION
This pull request mainly improves type hinting and code documentation across several integration and utility modules. The changes clarify the expected types for parameters and variables, enhance code comments, and correct some documentation for better maintainability and readability.

Type hinting and imports:

* Updated type hints for `options` in the `set_data` method of `BaseInterface` to use quoted string `"StyleOptions"` for consistency and to avoid issues with forward references.
* Moved imports of `MsgData`, `PostData`, `StatusData`, `MessageType`, and `StyleOptions` inside the `TYPE_CHECKING` block to optimize runtime imports and clarify their use for type checking only.

Documentation and comment improvements:

* Improved the docstring for the `message` attribute in the `PostData` class to clarify that it is a list of `(MessageType, StyleOptions)` pairs, rather than a dictionary keyed by identifiers.
* Updated the comment for the `transpose` attribute in `StyleOptions` to clarify its meaning when the `MessageType` is a DataFrame.
* Fixed a comment in the `name_replace` function to correctly describe the conversion from hiragana to katakana.