### PR TITLE
Refactor headline handling in MessageParser and related integrations

### DIFF
--- a/integrations/base/interface.py
+++ b/integrations/base/interface.py
@@ -158,12 +158,30 @@ class MessageParserDataMixin:
         self.post.reset()
         self.status.reset()
 
+    def set_headline(
+        self,
+        data: "MessageType",
+        options: "StyleOptions",
+    ):
+        """ヘッドラインメッセージをセット
+
+        Args:
+            data (MessageType): 内容
+            options (StyleOptions): 表示オプション
+        """
+
+        # 空データは登録しない
+        if isinstance(data, NoneType) or (isinstance(data, pd.DataFrame) and data.empty):
+            self.post.headline = None
+        else:
+            self.post.headline = (data, options)
+
     def set_data(
         self,
         data: "MessageType",
         options: "StyleOptions",
     ):
-        """メッセージデータをセット
+        """本文メッセージをセット
 
         Args:
             data (MessageType): 内容

--- a/integrations/discord/api.py
+++ b/integrations/discord/api.py
@@ -88,14 +88,17 @@ class AdapterAPI(APIInterface):
         header_title = ""
         header_text = ""
         if m.post.headline:
-            header_title, header_text = next(iter(m.post.headline.items()))
+            header_data, header_option = m.post.headline
+            header_title = header_option.title
+            if isinstance(header_data, str):
+                header_text = header_data
             m.post.thread_title = header_title
-            if not m.post.message:
-                thread_msg = await self.response.reply(f"{_header_text(header_title)}{header_text.rstrip()}")
-                m.post.thread = True
-            elif not all(options.header_hidden for _, options in m.post.message):
-                thread_msg = await self.response.reply(f"{_header_text(header_title)}{header_text.rstrip()}")
-                m.post.thread = True
+        if not m.post.message:
+            thread_msg = await self.response.reply(f"{_header_text(header_title)}{header_text.rstrip()}")
+            m.post.thread = True
+        elif not all(options.header_hidden for _, options in m.post.message):
+            thread_msg = await self.response.reply(f"{_header_text(header_title)}{header_text.rstrip()}")
+            m.post.thread = True
         elif m.post.thread_title:
             thread_msg = self.response
             m.post.thread = True

--- a/integrations/discord/events/comparison.py
+++ b/integrations/discord/events/comparison.py
@@ -45,7 +45,7 @@ async def _wrapper(m: "MessageParserProtocol"):
     await check_remarks(results, messages_list)
     await check_total_score(results, messages_list)
 
-    m.post.headline = {m.keyword: results.output("headline")}
+    m.set_headline(results.output("headline"), StyleOptions(title=m.keyword))
     m.set_data(results.output("mismatch"), StyleOptions(title="不一致", key_title=False))
     m.set_data(results.output("missing"), StyleOptions(title="取りこぼし", key_title=False))
     m.set_data(results.output("delete"), StyleOptions(title="削除漏れ", key_title=False))

--- a/integrations/protocols.py
+++ b/integrations/protocols.py
@@ -4,7 +4,7 @@ integrations/protocols.py
 
 from dataclasses import dataclass, field, fields, is_dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Optional, Protocol
 
 if TYPE_CHECKING:
     from pathlib import Path  # noqa: F401
@@ -120,7 +120,8 @@ class MsgData(DataMixin):
 class PostData(DataMixin):
     """ポストするデータ"""
 
-    headline: dict[str, str] = field(default_factory=dict)
+    """本文メッセージ"""
+    headline: Optional[tuple["MessageType", "StyleOptions"]] = field(default=None)
     """ヘッダ文"""
     message: list[tuple["MessageType", "StyleOptions"]] = field(default_factory=list)
     """本文
@@ -225,8 +226,11 @@ class MessageParserProtocol(Protocol):
     def ignore_user(self) -> bool:
         """コマンドを拒否するユーザか判定"""
 
+    def set_headline(self, data: "MessageType", options: "StyleOptions"):
+        """ヘッドラインメッセージをセット"""
+
     def set_data(self, data: "MessageType", options: "StyleOptions"):
-        """メッセージデータをセット"""
+        """本文メッセージをセット"""
 
     def get_remarks(self, keyword: str) -> list:
         """本文からメモデータを取り出す"""

--- a/integrations/slack/api.py
+++ b/integrations/slack/api.py
@@ -82,11 +82,14 @@ class AdapterAPI(APIInterface):
         header_title = ""
         header_text = ""
         if m.post.headline:
-            header_title, header_text = next(iter(m.post.headline.items()))
-            if not m.post.message:  # メッセージなし
-                _post_header()
-            elif not all(options.header_hidden for _, options in m.post.message):
-                _post_header()
+            header_data, header_option = m.post.headline
+            header_title = header_option.title
+            if isinstance(header_data, str):
+                header_text = header_data
+        if not m.post.message:  # メッセージなし
+            _post_header()
+        elif not all(options.header_hidden for _, options in m.post.message):
+            _post_header()
 
         # 本文
         options = StyleOptions()

--- a/integrations/slack/events/home_tab/ui_parts.py
+++ b/integrations/slack/events/home_tab/ui_parts.py
@@ -372,14 +372,11 @@ def update_view(adapter: "ServiceAdapter", m: "MessageParserProtocol", msg: list
         msg (list): 表示テキスト
     """
 
+    text = ""
     if m.post.headline:
-        if isinstance(m.post.headline, dict):
-            k, v = next(iter(m.post.headline.items()))
-            text = f"\n【{k}】\n{v}"
-        else:
-            text = m.post.headline
-    else:
-        text = ""
+        header_data, header_option = m.post.headline
+        if isinstance(header_data, str):
+            text = f"\n【{header_option.title}】\n{header_data}"
 
     adapter.api.appclient.views_update(
         view_id=adapter.conf.tab_var["view_id"],

--- a/integrations/standard_io/api.py
+++ b/integrations/standard_io/api.py
@@ -47,13 +47,14 @@ class AdapterAPI(APIInterface):
 
         # 見出し
         if m.post.headline:
-            title, text = next(iter(m.post.headline.items()))
-            if text:
+            header_data, header_option = m.post.headline
+            if isinstance(header_data, str):
                 print("=" * 80)
-                if not title.isnumeric() and title:
-                    print(f"【{title}】")
-                print(textwrap.dedent(text).rstrip())
-                print("=" * 80)
+                if header_option.title:
+                    print(f"【{header_option.title}】")
+                if isinstance(header_data, str):
+                    print(textwrap.dedent(header_data).rstrip())
+                    print("=" * 80)
 
         # 本文
         for data, options in m.post.message:

--- a/integrations/web/events/create_bp/detail.py
+++ b/integrations/web/events/create_bp/detail.py
@@ -41,10 +41,10 @@ def detail_bp(adapter: "ServiceAdapter") -> Blueprint:
         m.data.text = f"{g.cfg.results.commandword[0]} {text}"
         libs.dispatcher.by_keyword(m)
 
-        message = adapter.functions.header_message(m)
+        _, message = adapter.functions.header_message(m)
 
         for data, options in m.post.message:
-            if not options.title.isnumeric() and options.title:
+            if options.title:
                 message += f"<h2>{options.title}</h2>\n"
 
             if isinstance(data, pd.DataFrame):

--- a/integrations/web/events/create_bp/graph.py
+++ b/integrations/web/events/create_bp/graph.py
@@ -41,7 +41,7 @@ def graph_bp(adapter: "ServiceAdapter") -> Blueprint:
         m.data.text = f"{g.cfg.graph.commandword[0]} {text}"
         libs.dispatcher.by_keyword(m)
 
-        message = adapter.functions.header_message(m)
+        _, message = adapter.functions.header_message(m)
 
         for data, options in m.post.message:
             if isinstance(data, PosixPath) and data.exists():

--- a/integrations/web/events/create_bp/ranking.py
+++ b/integrations/web/events/create_bp/ranking.py
@@ -40,10 +40,10 @@ def ranking_bp(adapter: "ServiceAdapter") -> Blueprint:
         m.data.text = f"{g.cfg.ranking.commandword[0]} {text}"
         libs.dispatcher.by_keyword(m)
 
-        message = adapter.functions.header_message(m)
+        _, message = adapter.functions.header_message(m)
 
         for data, options in m.post.message:
-            if not options.title.isnumeric() and options.title:
+            if options.title:
                 message += f"<h2>{options.title}</h2>\n"
 
             if isinstance(data, pd.DataFrame):

--- a/integrations/web/events/create_bp/report.py
+++ b/integrations/web/events/create_bp/report.py
@@ -40,7 +40,7 @@ def report_bp(adapter: "ServiceAdapter") -> Blueprint:
         m.data.text = f"{g.cfg.report.commandword[0]} {text}"
         libs.dispatcher.by_keyword(m)
 
-        message = adapter.functions.header_message(m)
+        headline_title, message = adapter.functions.header_message(m)
 
         for data, options in m.post.message:
             if not options.title.isnumeric() and options.title:
@@ -48,7 +48,7 @@ def report_bp(adapter: "ServiceAdapter") -> Blueprint:
 
             if isinstance(data, pd.DataFrame):
                 show_index = options.show_index
-                if {"個人成績一覧", "チーム成績一覧"} & set(m.post.headline):
+                if {"個人成績一覧", "チーム成績一覧"} & set(headline_title):
                     check_column = data.columns.to_list()
                     multi = [
                         ("", "プレイヤー名" if g.params.get("individual", True) else "チーム名"),
@@ -70,7 +70,7 @@ def report_bp(adapter: "ServiceAdapter") -> Blueprint:
                         ("役満", "和了率") if {"役満和了数", "役満和了率"}.issubset(check_column) else None,
                     ]
                     data.columns = pd.MultiIndex.from_tuples([x for x in multi if x is not None])
-                elif "成績上位者" in m.post.headline.keys():
+                elif "成績上位者" in headline_title:
                     name = "名前" if g.params.get("individual", True) else "チーム"
                     check_column = data.columns.to_list()
                     multi = [

--- a/integrations/web/events/create_bp/summary.py
+++ b/integrations/web/events/create_bp/summary.py
@@ -40,10 +40,10 @@ def summary_bp(adapter: "ServiceAdapter") -> Blueprint:
         m.data.text = f"{g.cfg.results.commandword[0]} {text}"
         libs.dispatcher.by_keyword(m)
 
-        message = adapter.functions.header_message(m)
+        _, message = adapter.functions.header_message(m)
 
         for data, options in m.post.message:
-            if not options.title.isnumeric() and options.title:
+            if options.title:
                 message += f"<h2>{options.title}</h2>\n"
 
             if isinstance(data, pd.DataFrame):

--- a/integrations/web/functions.py
+++ b/integrations/web/functions.py
@@ -141,24 +141,27 @@ class SvcFunctions(FunctionsInterface):
 
         return ret
 
-    def header_message(self, m: "MessageParserProtocol") -> str:
+    def header_message(self, m: "MessageParserProtocol") -> tuple[str, str]:
         """ヘッダ情報取得
 
         Args:
             m (MessageParserProtocol): メッセージデータ
 
         Returns:
-            str: 取得文字列
+            tuple[str, str]: 取得文字列
         """
 
         message = ""
-        if m.post.headline:
-            title, headline = next(iter(m.post.headline.items()))
-            if not title.isnumeric() and title:
-                message = f"<h1>{title}</h1>\n"
-            message += f"<p>\n{headline.replace('\n', '<br>\n')}</p>\n"
+        title = ""
 
-        return message
+        if m.post.headline:
+            header_data, header_option = m.post.headline
+            if title := header_option.title:
+                message = f"<h1>{title}</h1>\n"
+            if isinstance(header_data, str):
+                message += f"<p>\n{header_data.replace('\n', '<br>\n')}</p>\n"
+
+        return title, message
 
     def set_cookie(self, html: str, req: "Request", data: dict) -> "Response":
         """cookie保存

--- a/libs/commands/graph/personal.py
+++ b/libs/commands/graph/personal.py
@@ -39,7 +39,7 @@ def plot(m: "MessageParserProtocol"):
     df = loader.read_data("SUMMARY_GAMEDATA")
 
     if df.empty:
-        m.post.headline = {"0": message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions())
         m.status.result = False
         return
 
@@ -60,7 +60,7 @@ def plot(m: "MessageParserProtocol"):
     else:
         title_range = f"({ExtDt(g.params['starttime']).format(Format.YMDHM)} - {ExtDt(g.params['endtime']).format(Format.YMDHM)})"
 
-    m.post.headline = {title_text: message.header(game_info, m)}
+    m.set_headline(message.header(game_info, m), StyleOptions(title=title_text))
     m.set_data(
         formatter.df_rename(df.drop(columns=["count", "name"]), StyleOptions()),
         StyleOptions(title="個人成績", header_hidden=True, key_title=False),
@@ -136,7 +136,7 @@ def statistics_plot(m: "MessageParserProtocol"):
     df = loader.read_data("SUMMARY_DETAILS")
 
     if df.empty:
-        m.post.headline = {"0": message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions())
         m.status.result = False
         return
 
@@ -151,7 +151,7 @@ def statistics_plot(m: "MessageParserProtocol"):
     player_df = df.query("name == @player").reset_index(drop=True)
 
     if player_df.empty:
-        m.post.headline = {"0": message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions())
         m.status.result = False
         return
 
@@ -235,7 +235,7 @@ def statistics_plot(m: "MessageParserProtocol"):
     rank_table["4位"] = count_df.apply(lambda row: f"{row['4位(%)']:.2%} ({row['4位']:.0f})", axis=1)
     rank_table["平均順位"] = count_df.apply(lambda row: f"{row['平均順位']:.2f}", axis=1)
 
-    m.post.headline = {f"『{player}』の成績": message.header(game_info, m)}
+    m.set_headline(message.header(game_info, m), StyleOptions(title=f"『{player}』の成績"))
 
     # --- グラフ生成
     graphutil.setup()

--- a/libs/commands/graph/rating.py
+++ b/libs/commands/graph/rating.py
@@ -34,7 +34,7 @@ def plot(m: "MessageParserProtocol"):
     title: str = "レーティング推移グラフ"
 
     if g.params.get("mode") == 3 or g.params.get("target_mode") == 3:  # todo: 未実装
-        m.post.headline = {title: message.random_reply(m, "not_implemented")}
+        m.set_headline(message.random_reply(m, "not_implemented"), StyleOptions(title=title))
         m.status.result = False
         return
 
@@ -43,7 +43,7 @@ def plot(m: "MessageParserProtocol"):
     df_ratings = aggregate.calculation_rating()
 
     if df_ratings.empty:
-        m.post.headline = {"0": message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions())
         m.status.result = False
         return
 
@@ -65,13 +65,13 @@ def plot(m: "MessageParserProtocol"):
         df_sorted = df_sorted.rename(columns=mapping_dict)
 
     if df_sorted.empty:
-        m.post.headline = {"0": message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions())
         m.status.result = False
         return
 
     # --- グラフ生成
     graphutil.setup()
-    m.post.headline = {title: message.header(game_info, m)}
+    m.set_headline(message.header(game_info, m), StyleOptions(title=title))
     match g.adapter.conf.plotting_backend:
         case "matplotlib":
             save_file = _graph_generation(game_info, df_sorted, "rating.png")

--- a/libs/commands/graph/summary.py
+++ b/libs/commands/graph/summary.py
@@ -49,7 +49,7 @@ def point_plot(m: "MessageParserProtocol"):
     target_data, df = _data_collection()
 
     if target_data.empty:  # 描写対象が0人の場合は終了
-        m.post.headline = {"0": message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions())
         m.status.result = False
         return
 
@@ -83,7 +83,7 @@ def point_plot(m: "MessageParserProtocol"):
             save_file = _graph_generation(graph_params)
 
     file_title = graph_params.get("title_text", "").split()[0]
-    m.post.headline = {f"{file_title}グラフ": message.header(game_info, m)}
+    m.set_headline(message.header(game_info, m), StyleOptions(title=f"{file_title}グラフ"))
     m.set_data(save_file, StyleOptions(title=file_title, use_comment=True, header_hidden=True, key_title=False))
 
 
@@ -99,7 +99,7 @@ def rank_plot(m: "MessageParserProtocol"):
     target_data, df = _data_collection()
 
     if target_data.empty:  # 描写対象が0人の場合は終了
-        m.post.headline = {"0": message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions())
         m.status.result = False
         return
 
@@ -134,7 +134,7 @@ def rank_plot(m: "MessageParserProtocol"):
             save_file = _graph_generation(graph_params)
 
     file_title = graph_params.get("title_text", "").split()[0]
-    m.post.headline = {f"{file_title}グラフ": message.header(game_info, m)}
+    m.set_headline(message.header(game_info, m), StyleOptions(title=f"{file_title}グラフ"))
     m.set_data(save_file, StyleOptions(title=file_title, use_comment=True, header_hidden=True, key_title=False))
 
 

--- a/libs/commands/ranking/ranking.py
+++ b/libs/commands/ranking/ranking.py
@@ -33,7 +33,7 @@ def aggregation(m: "MessageParserProtocol"):
     # データ取得
     game_info = GameInfo()
     if not game_info.count:  # 検索結果が0件のとき
-        m.post.headline = {title: message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions())
         m.status.result = False
         return
 
@@ -50,7 +50,7 @@ def aggregation(m: "MessageParserProtocol"):
     ).copy()
 
     if df.empty:
-        m.post.headline = {title: message.random_reply(m, "no_target")}
+        m.set_headline(message.random_reply(m, "no_target"), StyleOptions())
         m.status.result = False
         return
 
@@ -304,4 +304,4 @@ def aggregation(m: "MessageParserProtocol"):
             ),
         )
 
-    m.post.headline = {title: message.header(game_info, m, "", 1)}
+    m.set_headline(message.header(game_info, m, "", 1), StyleOptions(title=title))

--- a/libs/commands/ranking/rating.py
+++ b/libs/commands/ranking/rating.py
@@ -33,7 +33,7 @@ def aggregation(m: "MessageParserProtocol"):
     add_text: str = ""
 
     if g.params.get("mode") == 3 or g.params.get("target_mode") == 3:  # todo: 未実装
-        m.post.headline = {title: message.random_reply(m, "not_implemented")}
+        m.set_headline(message.random_reply(m, "not_implemented"), StyleOptions(title=title))
         m.status.result = False
         return
 
@@ -43,7 +43,7 @@ def aggregation(m: "MessageParserProtocol"):
     ranked = int(g.params.get("ranked", g.cfg.ranking.ranked))  # noqa: F841
 
     if not game_info.count:  # 検索結果が0件のとき
-        m.post.headline = {title: message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions())
         m.status.result = False
         return
 
@@ -84,7 +84,7 @@ def aggregation(m: "MessageParserProtocol"):
         df["name"] = df["name"].replace(mapping_dict)
 
     if df.empty:
-        m.post.headline = {title: message.random_reply(m, "no_target")}
+        m.set_headline(message.random_reply(m, "no_target"), StyleOptions())
         m.status.result = False
         return
 
@@ -92,7 +92,7 @@ def aggregation(m: "MessageParserProtocol"):
     df = df.query("rank <= @ranked").filter(items=["rank", "name", "rate", "rank_distr", "rank_avg", "rank_dev", "rpoint_avg", "point_dev", "grade"]).copy()
     df = formatter.df_drop(df, list(g.cfg.dropitems.ranking))
 
-    m.post.headline = {title: message.header(game_info, m, add_text, 1)}
+    m.set_headline(message.header(game_info, m, add_text, 1), StyleOptions(title=title))
     options: StyleOptions = StyleOptions(
         title=title,
         data_kind=StyleOptions.DataKind.RATING,

--- a/libs/commands/report/matrix.py
+++ b/libs/commands/report/matrix.py
@@ -31,7 +31,7 @@ def plot(m: "MessageParserProtocol"):
         df = df.rename(columns=mapping_dict, index=mapping_dict)
 
     if df.empty:
-        m.post.headline = {title: message.random_reply(m, "no_target")}
+        m.set_headline(message.random_reply(m, "no_target"), StyleOptions(title=title))
         m.status.result = False
         return
 
@@ -42,7 +42,7 @@ def plot(m: "MessageParserProtocol"):
         file_path = textutil.save_file_path("matrix.txt", True)
         df.to_markdown(file_path, tablefmt="outline")
 
-    m.post.headline = {title: message.header(game_info, m, "", 1)}
+    m.set_headline(message.header(game_info, m, "", 1), StyleOptions(title=title))
     match g.adapter.interface_type:
         case "slack" | "discord":
             m.set_data(file_path, StyleOptions(title=title, use_comment=True, header_hidden=True))

--- a/libs/commands/report/monthly.py
+++ b/libs/commands/report/monthly.py
@@ -29,7 +29,7 @@ def plot(m: "MessageParserProtocol"):
     results = df.transpose().to_dict()
 
     if len(results) == 0:
-        m.post.headline = {title: message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions(title=title))
         m.status.result = False
         return
 

--- a/libs/commands/report/stats_list.py
+++ b/libs/commands/report/stats_list.py
@@ -37,7 +37,7 @@ def main(m: "MessageParserProtocol"):
     df = loader.read_data("REPORT_RESULTS_LIST").reset_index(drop=True)
     df.index = df.index + 1
     if df.empty:
-        m.post.headline = {"成績一覧": message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions(title="成績一覧"))
         m.status.result = False
         return
 
@@ -71,7 +71,7 @@ def main(m: "MessageParserProtocol"):
         case _:
             file_path = graph_generation(game_info, df, title)
 
-    m.post.headline = {title: message.header(game_info, m)}
+    m.set_headline(message.header(game_info, m), StyleOptions(title=title))
     match g.adapter.interface_type:
         case "slack" | "discord":
             m.set_data(file_path, StyleOptions(title=title, use_comment=True, header_hidden=True))

--- a/libs/commands/report/stats_report.py
+++ b/libs/commands/report/stats_report.py
@@ -382,11 +382,11 @@ def gen_pdf(m: "MessageParserProtocol"):
 
     if g.adapter.conf.plotting_backend == "plotly":
         m.post.reset()
-        m.post.headline = {"": message.random_reply(m, "not_implemented")}
+        m.set_headline(message.random_reply(m, "not_implemented"), StyleOptions())
         return
 
     if not g.params.get("player_name"):  # レポート対象の指定なし
-        m.post.headline = {"成績レポート": message.random_reply(m, "no_target")}
+        m.set_headline(message.random_reply(m, "no_target"), StyleOptions(title="成績レポート"))
         m.status.result = False
         return
 
@@ -395,7 +395,7 @@ def gen_pdf(m: "MessageParserProtocol"):
     logging.debug(target_info)
 
     if not target_info["game_count"]:  # 記録なし
-        m.post.headline = {"成績レポート": message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions(title="成績レポート"))
         m.status.result = False
         return
 

--- a/libs/commands/report/winner.py
+++ b/libs/commands/report/winner.py
@@ -29,7 +29,7 @@ def plot(m: "MessageParserProtocol"):
     game_info = GameInfo()
     results_df = loader.read_data("REPORT_WINNER")
     if len(results_df) == 0:
-        m.post.headline = {"成績上位": message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions(title="成績上位"))
         m.status.result = False
         return
 
@@ -56,7 +56,7 @@ def plot(m: "MessageParserProtocol"):
                     str("{:+}".format(v[f"point{x}"])).replace("-", "▲"),
                 )
 
-    m.post.headline = {"成績上位者": message.header(game_info, m)}
+    m.set_headline(message.header(game_info, m), StyleOptions(title="成績上位者"))
 
     # --- グラフ設定
     match g.adapter.conf.plotting_backend:

--- a/libs/commands/results/detail.py
+++ b/libs/commands/results/detail.py
@@ -42,7 +42,7 @@ def aggregation(m: "MessageParserProtocol"):
             }
         )
         if (target_mode := g.params.get("target_mode")) and target_mode != g.cfg.rule.get_mode(rule_version):
-            m.post.headline = {"集計矛盾検出": message.random_reply(m, "rule_mismatch")}
+            m.set_headline(message.random_reply(m, "rule_mismatch"), StyleOptions(title="集計矛盾検出"))
             m.status.result = False
             return
     if g.params["player_name"] in g.cfg.team.lists:
@@ -67,9 +67,9 @@ def aggregation(m: "MessageParserProtocol"):
             msg_data["特記事項"] = "、".join(compose.text_item.remarks())
             msg_data["検索ワード"] = compose.text_item.search_word()
             msg_data["対戦数"] = f"0 戦 (0 勝 0 敗 0 分) {compose.badge.status(0, 0)}"
-            m.post.headline = {title: message_build(msg_data)}
+            m.set_headline(message_build(msg_data), StyleOptions(title=title))
         else:
-            m.post.headline = {title: "登録されていないチームです。"}
+            m.set_headline("登録されていないチームです。", StyleOptions(title=title))
         m.status.result = False
         return
 
@@ -77,7 +77,7 @@ def aggregation(m: "MessageParserProtocol"):
     stats.read(cast(dict, g.params))
 
     if stats.result_df.empty or stats.record_df.empty:
-        m.post.headline = {title: message.random_reply(m, "no_target")}
+        m.set_headline(message.random_reply(m, "no_target"), StyleOptions(title=title))
         m.status.result = False
         return
 
@@ -170,7 +170,7 @@ def aggregation(m: "MessageParserProtocol"):
     # 非表示項目を除外
     m.post.message = [(data, options) for data, options in m.post.message if options.title not in g.cfg.dropitems.results]
 
-    m.post.headline = {title: message_build(msg_data)}
+    m.set_headline(message_build(msg_data), StyleOptions(title=title))
 
 
 def comparison(m: "MessageParserProtocol"):
@@ -194,7 +194,7 @@ def comparison(m: "MessageParserProtocol"):
 
     # タイトル
     title = "成績詳細比較"
-    m.post.headline = {title: message.header(game_info, m, "", 1)}
+    m.set_headline(message.header(game_info, m, "", 1), StyleOptions(title=title))
 
     if not game_info.count:
         m.status.result = False
@@ -214,7 +214,7 @@ def comparison(m: "MessageParserProtocol"):
         stats_df = pd.concat([stats_df, work_stats.summary])
 
     if stats_df.empty:
-        m.post.headline = {"0": message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions())
         m.status.result = False
         return
 
@@ -222,7 +222,7 @@ def comparison(m: "MessageParserProtocol"):
     stipulated = g.params.get("stipulated", 1)  # noqa: F841
     stats_df.query("count >= @stipulated", inplace=True)
     if stats_df.empty:
-        m.post.headline = {"0": message.random_reply(m, "no_target")}
+        m.set_headline(message.random_reply(m, "no_target"), StyleOptions())
         m.status.result = False
         return
 

--- a/libs/commands/results/summary.py
+++ b/libs/commands/results/summary.py
@@ -48,21 +48,27 @@ def aggregation(m: "MessageParserProtocol"):
 
     add_text = "" if g.cfg.mahjong.ignore_flying else f" / トバされた人（延べ）：{df_summary['flying'].sum()} 人"
     header_text = message.header(game_info, m, add_text, 1)
-    m.post.headline = {headline_title: header_text}
+    m.set_headline(header_text, StyleOptions(title=headline_title))
 
     if df_summary.empty:
-        m.post.headline = {"0": message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions())
         m.status.result = False
         return
 
     # 通算ポイント
     options = StyleOptions(
         title="通算ポイント",
-        format_type=g.params["format"],
         codeblock=False,
         rename_type=StyleOptions.RenameType.SHORT,
         data_kind=StyleOptions.DataKind.POINTS_TOTAL,
     )
+    match g.params.get("format", "default").lower():
+        case "csv":
+            options.format_type = "csv"
+        case "txt" | "text":
+            options.format_type = "txt"
+        case _:
+            options.format_type = "default"
 
     header_list = ["name", "total_point", "avg_point", "rank_distr3", "rank_distr4", "flying"]
     filter_list = [
@@ -79,6 +85,7 @@ def aggregation(m: "MessageParserProtocol"):
         "rank_avg",
         "flying",
     ]
+
     if g.cfg.mahjong.ignore_flying or g.cfg.dropitems.results & g.cfg.dropitems.flying:  # トビカウントなし
         header_list.remove("flying")
         filter_list.remove("flying")
@@ -87,9 +94,10 @@ def aggregation(m: "MessageParserProtocol"):
         options.codeblock = True
         data = df_summary.filter(items=header_list)
     else:
+        options.title = headline_title
         options.base_name = "summary"
         df_summary = df_summary.filter(items=filter_list).fillna("*****")
-        data = converter.save_output(df_summary, options, f"【{headline_title}】\n{header_text}", "summary")
+        data = converter.save_output(df_summary, options, m.post.headline, "summary")
     m.set_data(data, StyleOptions(**options.asdict))
 
     # メモ(役満和了)
@@ -103,8 +111,7 @@ def aggregation(m: "MessageParserProtocol"):
             data = df_yakuman
         else:
             options.base_name = "yakuman"
-            data = converter.save_output(df_yakuman, options, f"【役満和了】\n{header_text}", "yakuman")
-
+            data = converter.save_output(df_yakuman, options, m.post.headline, "yakuman")
         m.set_data(data, StyleOptions(**options.asdict))
 
     # メモ(卓外清算)
@@ -122,8 +129,7 @@ def aggregation(m: "MessageParserProtocol"):
             data = df_regulations
         else:
             options.base_name = "regulations"
-            data = converter.save_output(df_regulations, options, f"【卓外清算】\n{header_text}", "regulations")
-
+            data = converter.save_output(df_regulations, options, m.post.headline, "regulations")
         m.set_data(data, StyleOptions(**options.asdict))
 
     # メモ(その他)
@@ -136,8 +142,7 @@ def aggregation(m: "MessageParserProtocol"):
             data = df_others
         else:
             options.base_name = "others"
-            data = converter.save_output(df_others, options, f"【その他】\n{header_text}", "others")
-
+            data = converter.save_output(df_others, options, m.post.headline, "others")
         m.set_data(data, StyleOptions(**options.asdict))
 
 
@@ -171,10 +176,10 @@ def difference(m: "MessageParserProtocol"):
 
     add_text = "" if g.cfg.mahjong.ignore_flying else f" / トバされた人（延べ）：{df_summary['flying'].sum()} 人"
     header_text = message.header(game_info, m, add_text, 1)
-    m.post.headline = {headline_title: header_text}
+    m.set_headline(header_text, StyleOptions(title=headline_title))
 
     if df_summary.empty:
-        m.post.headline = {"0": message.random_reply(m, "no_hits")}
+        m.set_headline(message.random_reply(m, "no_hits"), StyleOptions())
         m.status.result = False
         return
 
@@ -186,19 +191,21 @@ def difference(m: "MessageParserProtocol"):
         rename_type=StyleOptions.RenameType.SHORT,
         data_kind=StyleOptions.DataKind.POINTS_DIFF,
     )
+    match g.params.get("format", "default").lower():
+        case "csv":
+            options.format_type = "csv"
+        case "txt" | "text":
+            options.format_type = "txt"
+        case _:
+            options.format_type = "default"
 
     # 集計結果
     header_list = ["#", "name", "total_point", "diff_from_above", "diff_from_top"]
     filter_list = ["name", "count", "total_point", "diff_from_above", "diff_from_top"]
-    match g.params.get("format", "default").lower():
-        case "csv":
-            options.format_type = "csv"
-            data = converter.save_output(df_summary.filter(items=filter_list).fillna("*****"), options, f"【{headline_title}】\n{header_text}")
-        case "text" | "txt":
-            options.format_type = "txt"
-            data = converter.save_output(df_summary.filter(items=filter_list).fillna("*****"), options, f"【{headline_title}】\n{header_text}")
-        case _:
-            options.format_type = "default"
-            data = df_summary.filter(items=header_list)
 
+    if options.format_type == "default":
+        data = df_summary.filter(items=header_list)
+    else:
+        options.title = headline_title
+        data = converter.save_output(df_summary.filter(items=filter_list).fillna("*****"), options, m.post.headline)
     m.set_data(data, StyleOptions(**options.asdict))

--- a/libs/commands/results/versus.py
+++ b/libs/commands/results/versus.py
@@ -55,11 +55,11 @@ def aggregation(m: "MessageParserProtocol"):
     drop_name: list = []  # 対戦記録なしプレイヤー
 
     if len(df_vs) == 0:  # 検索結果なし
-        m.post.headline = {"直接対戦": "対戦記録が見つかりません。"}
+        m.set_headline("対戦記録が見つかりません。", StyleOptions(title="直接対戦"))
         m.status.result = False
         return
 
-    m.post.headline = {"直接対戦": tmpl_header(my_name, vs)}
+    m.set_headline(tmpl_header(my_name, vs), StyleOptions(title="直接対戦"))
     for vs_name in vs_list:
         title = f"{my_name} vs {vs_name}"
         if vs_name in vs_list:

--- a/libs/utils/converter.py
+++ b/libs/utils/converter.py
@@ -16,11 +16,13 @@ from libs.utils import formatter, textutil
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from libs.types import MessageType
+
 
 def save_output(
     df: pd.DataFrame,
     options: StyleOptions,
-    headline: Optional[Union[str, dict[str, str]]] = None,
+    headline: Optional[tuple["MessageType", StyleOptions]] = None,
     suffix: Optional[str] = None,
 ) -> Union["Path", None]:
     """指定されたフォーマットでdfを保存する
@@ -28,8 +30,8 @@ def save_output(
     Args:
         df (pd.DataFrame): 保存対象データ
         options (StyleOptions): 詳細オプション
-        headline (Optional[Union[str, dict], optional): 集計情報（ヘッダコメント）. Defaults to None.
-        suffix (Optional[str], optional): 保存ファイル名に追加する文字列. Defaults to None.
+        headline (tuple[MessageType, StyleOptions], optional): ヘッダコメント. Defaults to None.
+        suffix (str, optional): 保存ファイル名に追加する文字列. Defaults to None.
 
     Returns:
         Path: 保存したファイルパス
@@ -62,15 +64,18 @@ def save_output(
         save_file = save_file.with_name(f"{save_file.stem}_{suffix}{save_file.suffix}")
 
     with open(save_file, "w", encoding="utf-8") as writefile:
-        if headline is not None:  # ヘッダ書き込み
-            if isinstance(headline, dict):
-                title, headline = next(iter(headline.items()))
-                if options.key_title:
-                    writefile.writelines(f"# 【{title}】\n")
-            for line in headline.splitlines():
-                writefile.writelines(f"# {line}\n")
-            writefile.writelines("\n")
-        writefile.writelines(data)  # 本文書き込み
+        # ヘッダコメント書き込み
+        if headline:
+            headline_data, headline_option = headline
+            if options.key_title:
+                writefile.writelines(f"# 【{headline_option.title}】\n")
+            if isinstance(headline_data, str):
+                for line in headline_data.splitlines():
+                    writefile.writelines(f"# {line}\n")
+                writefile.writelines("\n")
+
+        # 本文書き込み
+        writefile.writelines(data)
 
     return save_file
 


### PR DESCRIPTION
This pull request refactors the handling of headline messages across multiple integrations and command modules. The main change is replacing the previous dictionary-based approach for storing headline messages with a tuple containing the message data and display options. This improves consistency and flexibility in how headline messages are processed and displayed. Additionally, all affected interfaces, protocols, and UI rendering logic have been updated to support the new structure.

Headline message structure and handling:

* Changed the `headline` field in `PostData` from a `dict[str, str]` to an `Optional[tuple["MessageType", "StyleOptions"]]`, and updated all related logic to use this new structure. (`integrations/protocols.py`)
* Added a new `set_headline` method to the base interface and protocol, replacing direct assignment to `headline` and ensuring consistent headline registration. (`integrations/base/interface.py`, `integrations/protocols.py`) [[1]](diffhunk://#diff-c045365c3be998ef34b9d013eab86adc952a9af653a66a18bfc19853c84e846fR161-R184) [[2]](diffhunk://#diff-3cd8ccde9a0511cf3d2e96e9288a7cfa5df845fd911a6aa564cd92a2f5ff7a68R229-R233)
* Refactored all usages of headline assignment in command modules to use `set_headline` instead of dictionary assignment. (`libs/commands/graph/personal.py`, `libs/commands/graph/rating.py`, `libs/commands/graph/summary.py`, `libs/commands/ranking/ranking.py`, `integrations/discord/events/comparison.py`) [[1]](diffhunk://#diff-cb9f46caefb61462e42dc7ffa34359c1341c5a5b4b4264db6ab8c748d812bd56L42-R42) [[2]](diffhunk://#diff-cb9f46caefb61462e42dc7ffa34359c1341c5a5b4b4264db6ab8c748d812bd56L63-R63) [[3]](diffhunk://#diff-cb9f46caefb61462e42dc7ffa34359c1341c5a5b4b4264db6ab8c748d812bd56L139-R139) [[4]](diffhunk://#diff-cb9f46caefb61462e42dc7ffa34359c1341c5a5b4b4264db6ab8c748d812bd56L154-R154) [[5]](diffhunk://#diff-cb9f46caefb61462e42dc7ffa34359c1341c5a5b4b4264db6ab8c748d812bd56L238-R238) [[6]](diffhunk://#diff-af343ac19c012f144a17c1d2ca0e380a0d604b5ced8debeb5a0148dbb016cce8L37-R37) [[7]](diffhunk://#diff-af343ac19c012f144a17c1d2ca0e380a0d604b5ced8debeb5a0148dbb016cce8L46-R46) [[8]](diffhunk://#diff-af343ac19c012f144a17c1d2ca0e380a0d604b5ced8debeb5a0148dbb016cce8L68-R74) [[9]](diffhunk://#diff-3d3413024488da3c96079d9224c26d78f8794488591e783b405b376ba0a45ccbL52-R52) [[10]](diffhunk://#diff-3d3413024488da3c96079d9224c26d78f8794488591e783b405b376ba0a45ccbL86-R86) [[11]](diffhunk://#diff-3d3413024488da3c96079d9224c26d78f8794488591e783b405b376ba0a45ccbL102-R102) [[12]](diffhunk://#diff-3d3413024488da3c96079d9224c26d78f8794488591e783b405b376ba0a45ccbL137-R137) [[13]](diffhunk://#diff-24c365d83e438f73f74cedd2c6403c078ae0bb11205ed7dea0d9fd27af76c7d1L36-R36) [[14]](diffhunk://#diff-24c365d83e438f73f74cedd2c6403c078ae0bb11205ed7dea0d9fd27af76c7d1L53-R53) [[15]](diffhunk://#diff-dbe08a2e2ba59bcf3e91478b11948a38136080e684d2f299f31282b0d0460ee6L48-R48)

Integration and display logic updates:

* Updated headline extraction and rendering logic in Discord, Slack, Standard IO, and web integrations to use the new tuple structure, including proper handling of `StyleOptions` and message data. (`integrations/discord/api.py`, `integrations/slack/api.py`, `integrations/standard_io/api.py`, `integrations/slack/events/home_tab/ui_parts.py`) [[1]](diffhunk://#diff-e70f2c4ac2e5530abf5bae8dede764a1abe586aec1781fb4dd21c822d3828c7bL91-R94) [[2]](diffhunk://#diff-c5bb1d09c9ee7902c6ccfdd9a3b6f9cea1101bc69fd2d9d6a4dd1caee050bb92L85-R88) [[3]](diffhunk://#diff-cff147136fd21841d2df77099f099329b7ac8061a1a0d588abfff3d4ce485e7dL50-R56) [[4]](diffhunk://#diff-28d1de4cab91cf6319599e445c9db4f5e3bf3e9002b398d7a8abc950c922230aL375-R379)
* Modified the web interface's `header_message` function to return both the headline title and formatted HTML, and updated all web event handlers to use this new return value. (`integrations/web/functions.py`, `integrations/web/events/create_bp/detail.py`, `integrations/web/events/create_bp/graph.py`, `integrations/web/events/create_bp/ranking.py`, `integrations/web/events/create_bp/summary.py`, `integrations/web/events/create_bp/report.py`) [[1]](diffhunk://#diff-cbf903373b29862e0b237803ddfb76e64e43b7a7885bb0348681081f6850936fL144-R164) [[2]](diffhunk://#diff-9918bb4b7f5427a4a5da6927a2cbc637781b7baec5ac94fe447b059ecdc29f19L44-R47) [[3]](diffhunk://#diff-7aa38bd2c1cbc4e0c437eafe1fe2c67f7441b5db1a53521d8c17aef72c95f9c4L44-R44) [[4]](diffhunk://#diff-3615aae5e1f2b353b952666a57933fcd634e496839c3d39b68cf1b822a9b0c71L43-R46) [[5]](diffhunk://#diff-fc38c463c03961e68df7e01ffd9ce25f76ff45005e26a9a33e234e21d5f19a54L43-R46) [[6]](diffhunk://#diff-b47aa3eca2f8c334b03a1df786e7d212e7d74cc01562fb41ba2b5fb60d177262L43-R51) [[7]](diffhunk://#diff-b47aa3eca2f8c334b03a1df786e7d212e7d74cc01562fb41ba2b5fb60d177262L73-R73)

Type and interface improvements:

* Updated type hints and imports to support the new headline structure, including the use of `Optional` and improved docstrings. (`integrations/protocols.py`)

These changes collectively standardize and simplify headline message handling, making the codebase easier to maintain and extend.