### PR TITLE
Develop

### DIFF
--- a/cls/rule.py
+++ b/cls/rule.py
@@ -342,7 +342,7 @@ class RuleSet:
             RuntimeError: 重複あり
         """
 
-        chk_word: str | "RuleData"
+        chk_word: str | RuleData
 
         try:
             # ルール識別子チェック

--- a/integrations/base/interface.py
+++ b/integrations/base/interface.py
@@ -2,7 +2,6 @@
 integrations/base/interface.py
 """
 
-import re
 from abc import ABC, abstractmethod
 from configparser import ConfigParser
 from dataclasses import dataclass, field
@@ -193,24 +192,6 @@ class MessageParserDataMixin:
             return
 
         self.post.message.append((data, options))
-
-    def get_remarks(self, keyword: str) -> list:
-        """textからメモを抽出する
-
-        Args:
-            keyword (str): メモ記録キーワード
-
-        Returns:
-            list: 結果
-        """
-
-        ret: list = []
-        if re.match(rf"^{keyword}", self.data.text):  # キーワードが先頭に存在するかチェック
-            text = self.data.text.replace(keyword, "").strip().split()
-            for name, matter in zip(text[0::2], text[1::2]):
-                ret.append([name, matter])
-
-        return ret
 
 
 class MessageParserInterface(ABC):

--- a/integrations/protocols.py
+++ b/integrations/protocols.py
@@ -120,13 +120,10 @@ class MsgData(DataMixin):
 class PostData(DataMixin):
     """ポストするデータ"""
 
-    """本文メッセージ"""
     headline: Optional[tuple["MessageType", "StyleOptions"]] = field(default=None)
-    """ヘッダ文"""
+    """ヘッダメッセージ"""
     message: list[tuple["MessageType", "StyleOptions"]] = field(default_factory=list)
-    """本文
-    MessageTypeとStyleOptionsのペアのリスト
-    """
+    """本文メッセージ"""
     thread: bool = field(default=True)
     """スレッドに返す"""
     ts: str = field(default="undetermined")

--- a/integrations/protocols.py
+++ b/integrations/protocols.py
@@ -229,9 +229,6 @@ class MessageParserProtocol(Protocol):
     def set_message(self, data: "MessageType", options: "StyleOptions"):
         """本文メッセージをセット"""
 
-    def get_remarks(self, keyword: str) -> list:
-        """本文からメモデータを取り出す"""
-
     def parser(self, body: Any):
         """メッセージ解析メソッド"""
 

--- a/integrations/slack/events/comparison.py
+++ b/integrations/slack/events/comparison.py
@@ -187,12 +187,11 @@ def check_remarks(results: ComparisonResults):
         results.remark_mod.append(remark)
 
     if results.remark_mod:
+        work_m.reset()
         for remark in results.remark_mod:
             work_m.data.event_ts = remark["event_ts"]
-            work_m.status.command_type = CommandType.COMPARISON
             work_m.data.channel_id = remark["source"].replace("slack_", "")
-        work_m.status.command_type = CommandType.COMPARISON  # リセットがかかるので再セット
-        work_m.data.channel_id = remark["source"].replace("slack_", "")
+            work_m.status.command_type = CommandType.COMPARISON
         modify.remarks_delete(work_m)
         modify.remarks_append(work_m, results.remark_mod)
 

--- a/integrations/slack/functions.py
+++ b/integrations/slack/functions.py
@@ -330,13 +330,8 @@ class SvcFunctions(FunctionsInterface):
             if match.ignore_user:  # 除外ユーザからのポストは破棄
                 logging.info("skip ignore user: %s", match.data.user_id)
                 continue
-
-            if remark := match.get_remarks(g.cfg.setting.remarks_word):
-                match.data.remarks = remark
-            else:  # 不一致は破棄
-                continue
-
-            remarks_matches.append(match)
+            if match.keyword == g.cfg.setting.remarks_word:
+                remarks_matches.append(match)
 
         # イベント詳細取得
         if remarks_matches:
@@ -383,7 +378,6 @@ class SvcFunctions(FunctionsInterface):
                             self.reaction_remove(icon=reaction_ok, ch=m.data.channel_id, ts=ts)
                         if not reaction_data.get("ng"):
                             self.reaction_append(icon=reaction_ng, ch=m.data.channel_id, ts=ts)
-                m.status.reset()
             case ActionStatus.DELETE:
                 for ts in m.status.target_ts:
                     self.reaction_remove(icon=reaction_ok, ch=m.data.channel_id, ts=ts)


### PR DESCRIPTION
This pull request focuses on simplifying and cleaning up message remark extraction logic, improving type annotations, and clarifying docstrings. The primary change is the removal of the `get_remarks` method from message-related classes, shifting the responsibility for remark extraction to higher-level logic. Additional minor improvements include updating type hints and docstrings for clarity.

**Remark extraction logic simplification:**
* Removed the `get_remarks` method from both `MessageParserInterface` and `PostData`, centralizing remark extraction logic elsewhere and reducing redundancy. [[1]](diffhunk://#diff-c045365c3be998ef34b9d013eab86adc952a9af653a66a18bfc19853c84e846fL197-L214) [[2]](diffhunk://#diff-3cd8ccde9a0511cf3d2e96e9288a7cfa5df845fd911a6aa564cd92a2f5ff7a68L235-L237)
* Updated the remark extraction in `pickup_remarks` to use direct keyword matching (`match.keyword == g.cfg.setting.remarks_word`) instead of calling `get_remarks`.

**Type annotation and documentation improvements:**
* Changed the type annotation of `chk_word` from `str | "RuleData"` to `str | RuleData` for improved type correctness in `rule.py`.
* Improved and clarified docstrings in `PostData` for `headline` and `message` fields.

**Minor logic and cleanup:**
* Removed an unnecessary import of `re` from `interface.py` as it is no longer used.
* Adjusted the order of status and channel assignments in `check_remarks` for proper reset and assignment.
* Removed an unnecessary status reset in `post_processing`, likely to prevent unintended side effects.