### PR TITLE
Fix response check in post method and handle missing text case in _ca…

### DIFF
--- a/integrations/slack/api.py
+++ b/integrations/slack/api.py
@@ -70,7 +70,7 @@ class AdapterAPI(APIInterface):
                 text=f"{_header_text(header_title)}{header_text.rstrip()}",
                 thread_ts=m.reply_ts,
             )
-            if res.status_code == 200:  # 見出しがある場合はスレッドにする
+            if res and res.status_code == 200:  # 見出しがある場合はスレッドにする
                 m.post.ts = res.get("ts", "undetermined")
             else:
                 m.post.ts = "undetermined"
@@ -169,6 +169,9 @@ class AdapterAPI(APIInterface):
         res = cast("SlackResponse", {})
         if kwargs["thread_ts"] == "0":
             kwargs.pop("thread_ts")
+
+        if not kwargs.get("text"):
+            return res
 
         try:
             res = self.appclient.chat_postMessage(**kwargs)


### PR DESCRIPTION
This pull request introduces minor improvements to error handling and input validation in the Slack integration. The main changes ensure that API calls are only made when appropriate and that response handling is more robust.

Slack API robustness and validation:

* Added a check to ensure that the response object `res` exists before accessing its `status_code` in `_post_header`, preventing potential attribute errors.
* Added a guard clause in `_call_chat_post_message` to return early if the `text` field is missing or empty, avoiding unnecessary API calls.…ll_chat_post_message