### PR TITLE
Develop

### DIFF
--- a/cls/rule.py
+++ b/cls/rule.py
@@ -267,6 +267,18 @@ class RuleSet:
 
         return int(self.to_dict(version).get("mode", 0))
 
+    def get_ignore_flying(self, version: str) -> bool:
+        """指定ルールバージョン識別子のトビカウントフラグを返す
+
+        Args:
+            version (str): ルールバージョン識別子
+
+        Returns:
+            bool: トビカウントフラグ
+        """
+
+        return self.to_dict(version).get("ignore_flying", False)
+
     def get_undefined_word(self, version: str) -> int:
         """指定ルールバージョン識別子の未定義ワードタイプを返す
 

--- a/libs/commands/ranking/ranking.py
+++ b/libs/commands/ranking/ranking.py
@@ -283,7 +283,7 @@ def aggregation(m: "MessageParserProtocol"):
         )
 
     # 項目整理
-    if g.cfg.mahjong.ignore_flying or g.cfg.dropitems.ranking & g.cfg.dropitems.flying:
+    if g.params.get("ignore_flying") or g.cfg.dropitems.ranking & g.cfg.dropitems.flying:
         data.pop("トビ率")
     if g.cfg.dropitems.ranking & g.cfg.dropitems.yakuman:
         data.pop("役満和了率")

--- a/libs/commands/report/stats_list.py
+++ b/libs/commands/report/stats_list.py
@@ -57,7 +57,7 @@ def main(m: "MessageParserProtocol"):
         df.drop(columns=["4th_count", "rank4_rate", "4th_mix"], inplace=True)
 
     # 非表示項目
-    if g.cfg.mahjong.ignore_flying or g.cfg.dropitems.report & g.cfg.dropitems.flying:
+    if g.params.get("ignore_flying") or g.cfg.dropitems.report & g.cfg.dropitems.flying:
         df = df.drop(columns=["flying_mix", "flying_count", "flying_rate"])
     if g.cfg.dropitems.report & g.cfg.dropitems.yakuman:
         df = df.drop(columns=["yakuman_mix", "yakuman_count", "yakuman_rate"])

--- a/libs/commands/results/detail.py
+++ b/libs/commands/results/detail.py
@@ -103,7 +103,7 @@ def aggregation(m: "MessageParserProtocol"):
         }
     )
 
-    if g.cfg.mahjong.ignore_flying or g.cfg.dropitems.results & g.cfg.dropitems.flying:
+    if g.params.get("ignore_flying") or g.cfg.dropitems.results & g.cfg.dropitems.flying:
         seat_data.drop(columns=["トビ"], inplace=True)
     if g.cfg.dropitems.results & g.cfg.dropitems.yakuman:
         seat_data.drop(columns=["役満和了"], inplace=True)
@@ -232,7 +232,7 @@ def comparison(m: "MessageParserProtocol"):
 
     # 非表示項目
     stats_df = stats_df.drop(columns=[x for x in g.cfg.dropitems.results if x in stats_df.columns.to_list()])
-    if g.cfg.mahjong.ignore_flying or g.cfg.dropitems.results & g.cfg.dropitems.flying:
+    if g.params.get("ignore_flying") or g.cfg.dropitems.results & g.cfg.dropitems.flying:
         stats_df = stats_df.drop(columns=["flying_rate-count"])
     if g.cfg.dropitems.results & g.cfg.dropitems.yakuman:
         stats_df = stats_df.drop(columns=["yakuman_rate-count"])

--- a/libs/commands/results/summary.py
+++ b/libs/commands/results/summary.py
@@ -46,7 +46,7 @@ def aggregation(m: "MessageParserProtocol"):
     else:  # チーム集計
         headline_title = "チーム成績サマリ"
 
-    add_text = "" if g.cfg.mahjong.ignore_flying else f" / トバされた人（延べ）：{df_summary['flying'].sum()} 人"
+    add_text = "" if g.params.get("ignore_flying") else f" / トバされた人（延べ）：{df_summary['flying'].sum()} 人"
     header_text = message.header(game_info, m, add_text, 1)
     m.set_headline(header_text, StyleOptions(title=headline_title))
 
@@ -86,7 +86,7 @@ def aggregation(m: "MessageParserProtocol"):
         "flying",
     ]
 
-    if g.cfg.mahjong.ignore_flying or g.cfg.dropitems.results & g.cfg.dropitems.flying:  # トビカウントなし
+    if g.params.get("ignore_flying") or g.cfg.dropitems.results & g.cfg.dropitems.flying:  # トビカウントなし
         header_list.remove("flying")
         filter_list.remove("flying")
 
@@ -174,7 +174,7 @@ def difference(m: "MessageParserProtocol"):
     else:  # チーム集計
         headline_title = "チーム成績サマリ"
 
-    add_text = "" if g.cfg.mahjong.ignore_flying else f" / トバされた人（延べ）：{df_summary['flying'].sum()} 人"
+    add_text = "" if g.params.get("ignore_flying") else f" / トバされた人（延べ）：{df_summary['flying'].sum()} 人"
     header_text = message.header(game_info, m, add_text, 1)
     m.set_headline(header_text, StyleOptions(title=headline_title))
 

--- a/libs/dispatcher.py
+++ b/libs/dispatcher.py
@@ -155,11 +155,6 @@ def message_changed(detection: GameResult, m: "MessageParserProtocol"):
         modify.reprocessing_remarks(m)
         return
 
-    # rule_version不一致 → スキップ
-    if record_data.rule_version != g.cfg.mahjong.rule_version:
-        logging.debug("skip (rule_version mismatch). event_ts=%s", m.data.event_ts)
-        return
-
     # 全条件クリア → 更新実行
     modify.db_update(detection, m)
 

--- a/libs/functions/compose/badge.py
+++ b/libs/functions/compose/badge.py
@@ -99,6 +99,7 @@ def grade(name: str, detail: bool = True) -> str:
     # 初期値
     point: int = 0  # 昇段ポイント
     grade_level: int = 0  # レベル(段位)
+    g.params.update({"player_name": name})
 
     result_df = loader.read_data("SELECT_ALL_RESULTS", cast(dict, g.params))
     addition_expression = g.cfg.badge.grade.table.get("addition_expression", "0")

--- a/libs/types.py
+++ b/libs/types.py
@@ -254,6 +254,11 @@ class PlaceholderDict(TypedDict, total=False):
     - *True*: 識別子別に集計
     - *False*: すべて集計
     """
+    ignore_flying: bool
+    """トビカウント表示フラグ
+    - *True*: 表示しない
+    - *False*: 表示する
+    """
 
     # 検索関連
     starttime: Union[str, "ExtendedDatetime", None]

--- a/libs/utils/dictutil.py
+++ b/libs/utils/dictutil.py
@@ -173,7 +173,12 @@ def placeholder(subcom: "SubCommand", m: "MessageParserProtocol") -> "Placeholde
         if rule_version := ret_dict.get("rule_version"):
             ret_dict.update({"rule_set": {rule_version: g.cfg.rule.to_dict(rule_version)}})
 
-    ret_dict.update({"undefined_word": g.cfg.rule.get_undefined_word(ret_dict.get("rule_version", g.cfg.mahjong.rule_version))})
+    ret_dict.update(
+        {
+            "undefined_word": g.cfg.rule.get_undefined_word(ret_dict.get("rule_version", g.cfg.mahjong.rule_version)),
+            "ignore_flying": g.cfg.rule.get_ignore_flying(ret_dict.get("rule_version", g.cfg.mahjong.rule_version)),
+        }
+    )
 
     if departure_time.range(search_range).start == ExtDt("1900-01-01 00:00:00.000000"):
         ret_dict.update(


### PR DESCRIPTION
This pull request introduces a more flexible way to handle the "ignore flying" (トビカウント非表示) flag throughout the codebase by making it version-dependent and passing it via parameters, rather than relying solely on global configuration. It also adds the `ignore_flying` property to the placeholder dictionary and updates how this flag is accessed in various reporting and aggregation functions.

**Enhancements to "ignore flying" flag handling:**

* Added `get_ignore_flying` method to the `Rule` class to fetch the "ignore flying" flag for a specific rule version, making the flag version-aware.
* Updated the placeholder dictionary (`PlaceholderDict`) to include an `ignore_flying` boolean property, ensuring this flag is available wherever placeholders are used.
* Modified the `placeholder` utility function to populate both `undefined_word` and the new `ignore_flying` flag based on the rule version, improving downstream access to these values.

**Refactoring of flag usage in reporting and aggregation:**

* Refactored multiple reporting and aggregation functions (`results/detail.py`, `results/summary.py`, `ranking/ranking.py`, `report/stats_list.py`) to use `g.params.get("ignore_flying")` instead of the global config, ensuring the flag is contextually accurate and consistent with the selected rule version. [[1]](diffhunk://#diff-1e42f0ec2db60cad05bf4dc95600dcc1a0004873c61af2466f9d8b2f7054c827L106-R106) [[2]](diffhunk://#diff-1e42f0ec2db60cad05bf4dc95600dcc1a0004873c61af2466f9d8b2f7054c827L235-R235) [[3]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eL49-R49) [[4]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eL89-R89) [[5]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eL177-R177) [[6]](diffhunk://#diff-24c365d83e438f73f74cedd2c6403c078ae0bb11205ed7dea0d9fd27af76c7d1L286-R286) [[7]](diffhunk://#diff-89eb906e3904536863adf4e393326751e380b430802513a6a8c4d4b3bc21c061L60-R60)

**Other improvements:**

* Updated the badge composition function to set `player_name` in `g.params` before querying results, ensuring parameter consistency.
* Removed an early return in the dispatcher that skipped updates on rule version mismatch, possibly to allow more flexible data handling.