### PR TITLE
Refactor separate flag resolution logic and add HOME_APP channel type…

### DIFF
--- a/cls/config.py
+++ b/cls/config.py
@@ -939,20 +939,3 @@ class AppConfig:
         if section_name:
             return section_name
         return ""
-
-    def resolve_separate_flag(self, section_name: Optional[str] = None) -> bool:
-        """メイン設定から優先度の高いセパレート設定フラグを取得する
-
-        Args:
-            section_name (Optional[str]): チャンネル個別設定セクション名
-
-        Returns:
-            bool: セパレート設定フラグ
-        """
-
-        for section in (section_name, self.selected_service, "setting"):
-            if section and self.main_parser.has_section(section):
-                if separate_flg := self.main_parser[section].getboolean("separate", False):
-                    return separate_flg
-
-        return False

--- a/integrations/protocols.py
+++ b/integrations/protocols.py
@@ -38,6 +38,8 @@ class ChannelType(StrEnum):
     """プライベートチャンネル"""
     DIRECT_MESSAGE = "direct_message"
     """ダイレクトメッセージ"""
+    HOME_APP = "home_app"
+    """home app for slack"""
     SEARCH = "search_api"
     """検索API"""
     UNDETERMINED = "undetermined"

--- a/integrations/slack/parser.py
+++ b/integrations/slack/parser.py
@@ -42,7 +42,7 @@ class MessageParser(MessageParserDataMixin, MessageParserInterface):
         elif _body.get("container"):  # Homeタブ
             self.data.user_id = str(cast(dict, _body["user"]).get("id", ""))
             self.data.channel_id = g.adapter.functions.get_dm_channel_id(self.data.user_id)
-            self.data.channel_type = ChannelType.CHANNEL
+            self.data.channel_type = ChannelType.HOME_APP
             self.data.text = "dummy"
         elif _body.get("iid"):  # 検索結果
             if _channel_id := str(cast(dict, _event["channel"]).get("id", "")):
@@ -130,6 +130,8 @@ class MessageParser(MessageParserDataMixin, MessageParserInterface):
                 case ChannelType.CHANNEL:  # public channel
                     ret = True
                 case ChannelType.PRIVATE:  # private channel
+                    ret = True
+                case ChannelType.HOME_APP:  # home app
                     ret = True
                 case ChannelType.DIRECT_MESSAGE:  # direct message
                     ret = False

--- a/libs/data/lookup.py
+++ b/libs/data/lookup.py
@@ -6,18 +6,20 @@ import logging
 from configparser import ConfigParser
 from contextlib import closing
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import libs.global_value as g
 from cls.score import GameResult
 from cls.timekit import ExtendedDatetime as ExtDt
 from cls.timekit import Format
+from integrations.protocols import ChannelType
 from libs.data import loader
 from libs.utils import dbutil
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from integrations.protocols import MessageParserProtocol
     from libs.types import MemberDataDict, PlaceholderDict, TeamDataDict
 
 
@@ -65,6 +67,47 @@ def get_config_value(
                 raise TypeError(f"Unsupported val_type: {val_type}")
 
     return value
+
+
+def resolve_separate_flag(m: "MessageParserProtocol") -> bool:
+    """優先度の高いセパレート設定フラグを取得する
+
+    Args:
+        m (MessageParserProtocol): メッセージデータ
+
+    Returns:
+        bool: セパレート設定フラグ
+    """
+
+    separate_flg: Optional[bool] = None
+
+    # DM / HomeApp(slack) はセパレートしない
+    if m.data.channel_type in {ChannelType.DIRECT_MESSAGE, ChannelType.HOME_APP}:
+        return False
+
+    if g.cfg.main_parser.has_section(m.status.source):
+        # チャンネル個別ファイル内設定
+        if channel_config := g.cfg.main_parser[m.status.source].get("channel_config"):
+            separate_flg = get_config_value(config_file=Path(channel_config), section="setting", name="separate", val_type=bool)
+            if separate_flg is not None:
+                return separate_flg
+        # チャンネル設定
+        else:
+            separate_flg = get_config_value(config_file=g.cfg.config_file, section=m.status.source, name="separate", val_type=bool)
+            if separate_flg is not None:
+                return separate_flg
+
+    # サービス別設定
+    separate_flg = get_config_value(config_file=g.cfg.config_file, section=g.adapter.interface_type, name="separate", val_type=bool)
+    if separate_flg is not None:
+        return separate_flg
+
+    # メイン設定
+    separate_flg = get_config_value(config_file=g.cfg.config_file, section="setting", name="separate", val_type=bool)
+    if separate_flg is not None:
+        return separate_flg
+
+    return False
 
 
 def member_info(params: "PlaceholderDict") -> dict[str, Any]:

--- a/libs/dispatcher.py
+++ b/libs/dispatcher.py
@@ -27,7 +27,7 @@ def by_keyword(m: "MessageParserProtocol"):
         {
             "channel_config": g.cfg.read_channel_config(m.status.source),
             "source": g.cfg.resolve_channel_id(m.status.source),
-            "separate": g.cfg.resolve_separate_flag(m.status.source),
+            "separate": lookup.resolve_separate_flag(m),
         }
     )
 

--- a/libs/functions/compose/msg_print.py
+++ b/libs/functions/compose/msg_print.py
@@ -20,13 +20,13 @@ def help_message(m: "MessageParserProtocol"):
     """チャンネル内呼び出しキーワード用ヘルプ
 
     Args:
-        m (MessageParserProtocol): _description_
+        m (MessageParserProtocol): メッセージデータ
     """
 
     g.params.update(
         {
             "source": g.cfg.resolve_channel_id(m.status.source),
-            "separate": g.cfg.resolve_separate_flag(m.status.source),
+            "separate": lookup.resolve_separate_flag(m),
         }
     )
     g.cfg.rule.status_update(cast(dict, g.params))

--- a/libs/utils/dictutil.py
+++ b/libs/utils/dictutil.py
@@ -50,7 +50,7 @@ def placeholder(subcom: "SubCommand", m: "MessageParserProtocol") -> "Placeholde
             "guest_name": g.cfg.member.guest_name,
             "undefined_word": g.cfg.undefined_word,
             "source": g.cfg.resolve_channel_id(m.status.source),
-            "separate": g.cfg.resolve_separate_flag(m.status.source),
+            "separate": lookup.resolve_separate_flag(m),
             "rule_set": {},
             **g.cfg.setting.to_dict(drop_items=["separate"]),
             **subcom.to_dict(),  # デフォルト値


### PR DESCRIPTION
This pull request introduces a new `HOME_APP` channel type for Slack, updates how the "separate" configuration flag is resolved, and refactors related code to improve maintainability and clarity. The changes ensure that the "separate" flag is correctly determined based on message context, especially for new channel types, and centralize the resolution logic.

**Channel type enhancements:**

* Added `HOME_APP` as a new value to the `ChannelType` enum in `integrations/protocols.py`, representing Slack's Home App context.
* Updated Slack message parsing in `integrations/slack/parser.py` to assign `ChannelType.HOME_APP` when handling Home tab events, and allowed updates for this channel type in `check_updatable`. [[1]](diffhunk://#diff-8210fd02189a56ec626b50250ffecb24f0cc98ce16b46ebda41721243e282e97L45-R45) [[2]](diffhunk://#diff-8210fd02189a56ec626b50250ffecb24f0cc98ce16b46ebda41721243e282e97R134-R135)

**Configuration flag resolution refactoring:**

* Removed the `resolve_separate_flag` method from `cls/config.py` and replaced it with a new function `resolve_separate_flag` in `libs/data/lookup.py`. This new function centralizes and clarifies the logic for determining the "separate" flag, including handling for `DIRECT_MESSAGE` and `HOME_APP` channel types. [[1]](diffhunk://#diff-88cde354b26d3d685a7a5445aa7cc10d1411e1ce86e852cf75eb07bfd06493a4L942-L958) [[2]](diffhunk://#diff-ed78eb35f9d901f1b545673d5b3b6928e253c1a53f1be315a98658c7aae0d241R72-R112)

**Codebase updates to use new flag resolution:**

* Updated all usages of the old `resolve_separate_flag` to use the new `lookup.resolve_separate_flag` function in `libs/dispatcher.py`, `libs/functions/compose/msg_print.py`, and `libs/utils/dictutil.py`. [[1]](diffhunk://#diff-f7f2d5ef6441ca6bd83fb6b712c662c54bbab01a8f8dd2c6e9aa04e5a8082609L30-R30) [[2]](diffhunk://#diff-6ac831023a6f31c8f3d0d78278abe11fb7fd8bf599548313486085f5f33d0ecdL23-R29) [[3]](diffhunk://#diff-153c14825269c8bdceb5e846bbd56b21e5623f3865cbac664677cdd9e01d46b1L53-R53)

**Dependency and import adjustments:**

* Updated imports in `libs/data/lookup.py` to support the new function and type usage.… support