### PR TITLE
Develop

### DIFF
--- a/integrations/discord/config.py
+++ b/integrations/discord/config.py
@@ -45,7 +45,7 @@ class SvcConfig(BaseSection, IntegrationsConfig):
 
     def __post_init__(self):
         assert self.main_conf
-        self._parser = self.main_conf
+        self.main_parser = self.main_conf
         self.section = "discord"
         super().__init__(self)
         logging.debug("discord: %s", self)

--- a/integrations/factory.py
+++ b/integrations/factory.py
@@ -2,7 +2,7 @@
 integrations/factory.py
 """
 
-from typing import TYPE_CHECKING, Literal, cast, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 from integrations.discord.adapter import ServiceAdapter as discord_adapter
 from integrations.slack.adapter import ServiceAdapter as slack_adapter
@@ -10,8 +10,6 @@ from integrations.standard_io.adapter import ServiceAdapter as std_adapter
 from integrations.web.adapter import ServiceAdapter as web_adapter
 
 if TYPE_CHECKING:
-    from configparser import ConfigParser
-
     from integrations.base.interface import AdapterInterface
     from libs.bootstrap.app_config import AppConfig
 
@@ -46,16 +44,14 @@ def select_adapter(selected_service: str, conf: "AppConfig") -> "AdapterInterfac
         AdapterType: アダプタインターフェース
     """
 
-    parser = cast("ConfigParser", getattr(conf, "_parser"))
-
     match selected_service:
         case "slack":
-            return slack_adapter(parser)
+            return slack_adapter(conf.main_parser)
         case "discord":
-            return discord_adapter(parser)
+            return discord_adapter(conf.main_parser)
         case "web":
-            return web_adapter(parser)
+            return web_adapter(conf.main_parser)
         case "standard_io":
-            return std_adapter(parser)
+            return std_adapter(conf.main_parser)
         case _:
             raise ValueError(f"Unknown service: {selected_service}")

--- a/integrations/slack/config.py
+++ b/integrations/slack/config.py
@@ -63,7 +63,7 @@ class SvcConfig(BaseSection, IntegrationsConfig):
 
     def __post_init__(self):
         assert self.main_conf
-        self._parser = self.main_conf
+        self.main_parser = self.main_conf
         self.section = "slack"
         super().__init__(self)
         logging.debug("slack: %s", self)

--- a/integrations/standard_io/config.py
+++ b/integrations/standard_io/config.py
@@ -20,6 +20,6 @@ class SvcConfig(BaseSection, IntegrationsConfig):
     def __post_init__(self):
         assert self.main_conf
         self.section = "standard_io"
-        self._parser = self.main_conf
+        self.main_parser = self.main_conf
         super().__init__(self)
         logging.debug("standard_io: %s", self)

--- a/integrations/web/config.py
+++ b/integrations/web/config.py
@@ -62,7 +62,7 @@ class SvcConfig(BaseSection, IntegrationsConfig):
 
     def __post_init__(self):
         assert self.main_conf
-        self._parser = self.main_conf
+        self.main_parser = self.main_conf
         self.section = "web"
         super().__init__(self)
         logging.debug("web: %s", self)

--- a/libs/bootstrap/__init__.py
+++ b/libs/bootstrap/__init__.py
@@ -1,7 +1,7 @@
 """
 アプリケーション起動処理
 
-- `libs.bootstrap.app_config`: 設定関連
-- `libs.bootstrap.section`: セクション設定取り込み
 - `libs.bootstrap.configuration`: 初期設定関数
+- `libs.bootstrap.app_config`: アプリケーション設定関連
+- `libs.bootstrap.section`: セクション情報取り込み
 """

--- a/libs/bootstrap/app_config.py
+++ b/libs/bootstrap/app_config.py
@@ -7,7 +7,7 @@ import sys
 from configparser import ConfigParser
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 from libs.bootstrap.section import AliasSection, BaseSection, MahjongSection, SettingSection
 from libs.commands.graph.entry import GraphConfig
@@ -20,6 +20,9 @@ from libs.commands.results.entry import ResultsConfig
 from libs.data.lookup import read_memberslist
 from libs.domain.rule import RuleSet
 from libs.types import GradeTableDict
+
+if TYPE_CHECKING:
+    from libs.bootstrap.section import SubCommands
 
 
 class DropItems(BaseSection):
@@ -92,7 +95,7 @@ class AppConfig:
         """メイン設定ファイルパス"""
 
         try:
-            self.main_parser = ConfigParser()
+            self.main_parser: ConfigParser = ConfigParser()
             self.main_parser.read(self.config_file, encoding="utf-8")
         except Exception as err:
             raise RuntimeError(err) from err
@@ -116,9 +119,9 @@ class AppConfig:
                 self.main_parser.add_section(x)
 
         # 基本設定
-        self.script_dir = Path(sys.argv[0]).absolute().parent
+        self.script_dir: Path = Path(sys.argv[0]).absolute().parent
         """スクリプトが保存されているディレクトリパス"""
-        self.config_dir = self.config_file.absolute().parent
+        self.config_dir: Path = self.config_file.absolute().parent
         """設定ファイルが保存されているディレクトリパス"""
         self.selected_service: Literal["slack", "discord", "web", "standard_io"] = "slack"
         """連携先サービス"""
@@ -143,15 +146,15 @@ class AppConfig:
         """バッジ設定"""
 
         # サブコマンド
-        self.results: ResultsConfig = ResultsConfig()
+        self.results: "SubCommands" = ResultsConfig()
         """resultsセクション設定値"""
-        self.graph: GraphConfig = GraphConfig()
+        self.graph: "SubCommands" = GraphConfig()
         """graphセクション設定値"""
-        self.ranking: RankingConfig = RankingConfig()
+        self.ranking: "SubCommands" = RankingConfig()
         """rankingセクション設定値"""
-        self.report: ReportConfig = ReportConfig()
+        self.report: "SubCommands" = ReportConfig()
         """reportセクション設定値"""
-        self.help: HelpConfig = HelpConfig()
+        self.help: "SubCommands" = HelpConfig()
         """helpセクション設定値"""
 
         # 共通設定値

--- a/libs/bootstrap/app_config.py
+++ b/libs/bootstrap/app_config.py
@@ -25,27 +25,43 @@ from libs.types import GradeTableDict
 class DropItems(BaseSection):
     """非表示項目リスト"""
 
+    section: str
+    results: set[str]
+    """成績サマリ非表示項目"""
+    ranking: set[str]
+    """ランキング/レーティング非表示項目"""
+    report: set[str]
+    """レポート非表示項目"""
+    flying: set[str]
+    """トビ関連データ非表示指定ワード"""
+    yakuman: set[str]
+    """役満和了関連データ非表示指定ワード"""
+    regulation: set[str]
+    """卓外清算関連データ非表示指定ワード"""
+    other: set[str]
+    """メモ関連データ非表示指定ワード"""
+
     def __init__(self, outer: "AppConfig"):
         self.main_parser = outer.main_parser
 
         # 設定値取り込み
-        super().__init__(self)
-        self.results: set = {x.strip() for x in self.main_parser.get("results", "dropitems", fallback="").split(",")}
-        """成績サマリ非表示項目"""
-        self.ranking: set = {x.strip() for x in self.main_parser.get("ranking", "dropitems", fallback="").split(",")}
-        """ランキング/レーティング非表示項目"""
-        self.report: set = {x.strip() for x in self.main_parser.get("report", "dropitems", fallback="").split(",")}
-        """レポート非表示項目"""
+        self.section = "results"
+        self.section_proxy = self.main_parser[self.section]
+        self.results = set(self.getlist("dropitems", fallback=""))
+
+        self.section = "ranking"
+        self.section_proxy = self.main_parser[self.section]
+        self.ranking = set(self.getlist("dropitems", fallback=""))
+
+        self.section = "report"
+        self.section_proxy = self.main_parser[self.section]
+        self.report = set(self.getlist("dropitems", fallback=""))
 
         # 固定ワード
         self.flying = {"トビ", "トビ率"}
-        """トビ関連データ非表示指定ワード"""
         self.yakuman = {"役満", "役満和了", "役満和了率"}
-        """役満和了関連データ非表示指定ワード"""
         self.regulation = {"卓外", "卓外清算", "卓外ポイント"}
-        """卓外清算関連データ非表示指定ワード"""
         self.other = {"その他", "メモ"}
-        """メモ関連データ非表示指定ワード"""
 
 
 class BadgeDisplay(BaseSection):
@@ -72,11 +88,12 @@ class AppConfig:
     """アプリケーション設定"""
 
     def __init__(self, config_file: Path):
-        self.config_file = config_file
+        self.config_file: Path = config_file
+        """メイン設定ファイルパス"""
+
         try:
             self.main_parser = ConfigParser()
             self.main_parser.read(self.config_file, encoding="utf-8")
-            self._parser = self.main_parser
         except Exception as err:
             raise RuntimeError(err) from err
 
@@ -95,8 +112,8 @@ class AppConfig:
             "keyword_mapping",
         ]
         for x in option_sections:
-            if x not in self._parser.sections():
-                self._parser.add_section(x)
+            if x not in self.main_parser.sections():
+                self.main_parser.add_section(x)
 
         # 基本設定
         self.script_dir = Path(sys.argv[0]).absolute().parent
@@ -107,34 +124,34 @@ class AppConfig:
         """連携先サービス"""
 
         # 設定値
-        self.setting = SettingSection()
+        self.setting: SettingSection = SettingSection()
         """settingセクション設定値"""
-        self.mahjong = MahjongSection()
+        self.mahjong: MahjongSection = MahjongSection()
         """mahjongセクション設定値"""
-        self.alias = AliasSection()
+        self.alias: AliasSection = AliasSection()
         """aliasセクション設定値"""
 
-        self.member = MemberSection(self)
+        self.member: MemberSection = MemberSection(self)
         """memberセクション設定値"""
-        self.team = TeamSection(self)
+        self.team: TeamSection = TeamSection(self)
         """teamセクション設定値"""
 
-        self.dropitems = DropItems(self)
+        self.dropitems: DropItems = DropItems(self)
         """非表示項目"""
 
-        self.badge = BadgeDisplay(self)
+        self.badge: BadgeDisplay = BadgeDisplay(self)
         """バッジ設定"""
 
         # サブコマンド
-        self.results = ResultsConfig()
+        self.results: ResultsConfig = ResultsConfig()
         """resultsセクション設定値"""
-        self.graph = GraphConfig()
+        self.graph: GraphConfig = GraphConfig()
         """graphセクション設定値"""
-        self.ranking = RankingConfig()
+        self.ranking: RankingConfig = RankingConfig()
         """rankingセクション設定値"""
-        self.report = ReportConfig()
+        self.report: ReportConfig = ReportConfig()
         """reportセクション設定値"""
-        self.help = HelpConfig()
+        self.help: HelpConfig = HelpConfig()
         """helpセクション設定値"""
 
         # 共通設定値
@@ -153,8 +170,6 @@ class AppConfig:
 
     def initialization(self):
         """設定ファイル読み込み"""
-
-        self._parser = self.main_parser
 
         self.mahjong.config_load(self)
         self.setting.config_load(self)
@@ -204,8 +219,8 @@ class AppConfig:
             return
 
         try:
-            self._parser = ConfigParser()
-            self._parser.read([self.config_file, additional_config], encoding="utf-8")
+            self.additional_config_parser = ConfigParser()
+            self.additional_config_parser.read([self.config_file, additional_config], encoding="utf-8")
         except Exception as err:
             logging.error(err)
             return

--- a/libs/bootstrap/app_config.py
+++ b/libs/bootstrap/app_config.py
@@ -26,15 +26,15 @@ class DropItems(BaseSection):
     """非表示項目リスト"""
 
     def __init__(self, outer: "AppConfig"):
-        self._parser = outer._parser
+        self.main_parser = outer.main_parser
 
         # 設定値取り込み
         super().__init__(self)
-        self.results: set = {x.strip() for x in self._parser.get("results", "dropitems", fallback="").split(",")}
+        self.results: set = {x.strip() for x in self.main_parser.get("results", "dropitems", fallback="").split(",")}
         """成績サマリ非表示項目"""
-        self.ranking: set = {x.strip() for x in self._parser.get("ranking", "dropitems", fallback="").split(",")}
+        self.ranking: set = {x.strip() for x in self.main_parser.get("ranking", "dropitems", fallback="").split(",")}
         """ランキング/レーティング非表示項目"""
-        self.report: set = {x.strip() for x in self._parser.get("report", "dropitems", fallback="").split(",")}
+        self.report: set = {x.strip() for x in self.main_parser.get("report", "dropitems", fallback="").split(",")}
         """レポート非表示項目"""
 
         # 固定ワード
@@ -63,13 +63,13 @@ class BadgeDisplay(BaseSection):
 
     def __init__(self, outer: "AppConfig"):
         self.section = "grade"
-        self._parser = outer._parser
+        self.main_parser = outer.main_parser
 
-        self.grade.table_name = self._parser.get(self.section, "table_name", fallback="")
+        self.grade.table_name = self.main_parser.get(self.section, "table_name", fallback="")
 
 
 class AppConfig:
-    """コンフィグ解析クラス"""
+    """アプリケーション設定"""
 
     def __init__(self, config_file: Path):
         self.config_file = config_file
@@ -114,9 +114,9 @@ class AppConfig:
         self.alias = AliasSection()
         """aliasセクション設定値"""
 
-        self.member = MemberSection()
+        self.member = MemberSection(self)
         """memberセクション設定値"""
-        self.team = TeamSection()
+        self.team = TeamSection(self)
         """teamセクション設定値"""
 
         self.dropitems = DropItems(self)

--- a/libs/bootstrap/section.py
+++ b/libs/bootstrap/section.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, TypeAlias, Union
 from libs.domain.datamodels import CommandAttrs
 
 if TYPE_CHECKING:
-    from configparser import SectionProxy
+    from configparser import ConfigParser, SectionProxy
 
     from libs.bootstrap.app_config import AppConfig
     from libs.types import ServiceClassType, SettingClassType
@@ -26,40 +26,40 @@ SubClassType: TypeAlias = Union[
 class CommonMethodMixin:
     """共通メソッド"""
 
-    _section: "SectionProxy"
+    section_proxy: "SectionProxy"
     """読み込み先(パーサー + セクション名)"""
 
     def get(self, key: str, fallback: Any = None) -> Any:
         """値の取得"""
-        return self._section.get(key, fallback)
+        return self.section_proxy.get(key, fallback)
 
     def getint(self, key: str, fallback: int = 0) -> int:
         """整数値の取得"""
-        return self._section.getint(key, fallback)
+        return self.section_proxy.getint(key, fallback)
 
     def getfloat(self, key: str, fallback: float = 0.0) -> float:
         """数値の取得"""
-        return self._section.getfloat(key, fallback)
+        return self.section_proxy.getfloat(key, fallback)
 
     def getboolean(self, key: str, fallback: bool = False) -> bool:
         """真偽値の取得"""
-        return self._section.getboolean(key, fallback)
+        return self.section_proxy.getboolean(key, fallback)
 
     def getlist(self, key: str, fallback: str = "") -> list[str]:
         """リストの取得"""
-        return [x.strip() for x in self._section.get(key, fallback).split(",")]
+        return [x.strip() for x in self.section_proxy.get(key, fallback).split(",")]
 
     def keys(self) -> list[str]:
         """キーリストの返却"""
-        return list(self._section.keys())
+        return list(self.section_proxy.keys())
 
     def values(self) -> list:
         """値リストの返却"""
-        return list(self._section.values())
+        return list(self.section_proxy.values())
 
     def items(self) -> list[tuple]:
         """ItemsViewを返却"""
-        return list(self._section.items())
+        return list(self.section_proxy.items())
 
 
 class BaseSection(CommonMethodMixin):
@@ -67,13 +67,17 @@ class BaseSection(CommonMethodMixin):
 
     section: str
     """セクション名"""
+    main_parser: "ConfigParser"
+    """設定パーサー"""
+    section_proxy: "SectionProxy"
+    """読み込み先(パーサー + セクション名)"""
 
     def __init__(self, outer: SubClassType):
         self.main_parser = outer.main_parser
         assert self.main_parser
         if not hasattr(self, "section") or self.section not in self.main_parser:
             return
-        self._section = self.main_parser[self.section]
+        self.section_proxy = self.main_parser[self.section]
 
         self.initialization()
 
@@ -83,7 +87,7 @@ class BaseSection(CommonMethodMixin):
     def initialization(self):
         """設定ファイルから値の取り込み"""
 
-        for k in self._section.keys():
+        for k in self.section_proxy.keys():
             if k not in self.to_dict():
                 continue  # インスタンス変数と一致しない項目はスキップ
             match type(self.__dict__.get(k)):
@@ -94,7 +98,7 @@ class BaseSection(CommonMethodMixin):
                 case v_type if k in self.__dict__ and v_type is float:
                     setattr(self, k, self.getfloat(k))
                 case v_type if v_type is bool:
-                    setattr(self, k, self._section.getboolean(k))
+                    setattr(self, k, self.section_proxy.getboolean(k))
                 case v_type if k in self.__dict__ and v_type is list:
                     v_list = self.getlist(k)
                     current_list = getattr(self, k)
@@ -375,7 +379,7 @@ class SubCommands(BaseSection, CommandAttrs):
         """
 
         self.main_parser = outer.main_parser
-        self._section = outer.main_parser[self.section]
+        self.section_proxy = outer.main_parser[self.section]
         self.default_reset()
         super().__init__(self)
 

--- a/libs/bootstrap/section.py
+++ b/libs/bootstrap/section.py
@@ -69,11 +69,11 @@ class BaseSection(CommonMethodMixin):
     """セクション名"""
 
     def __init__(self, outer: SubClassType):
-        parser = outer._parser
-        assert parser
-        if not hasattr(self, "section") or self.section not in parser:
+        self.main_parser = outer.main_parser
+        assert self.main_parser
+        if not hasattr(self, "section") or self.section not in self.main_parser:
             return
-        self._section = parser[self.section]
+        self._section = self.main_parser[self.section]
 
         self.initialization()
 
@@ -173,7 +173,7 @@ class MahjongSection(BaseSection):
             outer (AppConfig): 設定クラスオブジェクト
         """
 
-        self._parser = outer._parser
+        self.main_parser = outer.main_parser
         super().__init__(self)
 
         # デフォルト値
@@ -263,7 +263,7 @@ class SettingSection(BaseSection):
             outer (AppConfig): 設定クラスオブジェクト
         """
 
-        self._parser = outer._parser
+        self.main_parser = outer.main_parser
         self._reset()
         super().__init__(self)
 
@@ -349,13 +349,12 @@ class AliasSection(BaseSection):
             outer (AppConfig): 設定クラスオブジェクト
         """
 
-        self._parser = outer._parser
+        self.main_parser = outer.main_parser
         self._reset()
         super().__init__(self)
 
         # delのエイリアス取り込み(設定ファイルに`delete`と書かれていない)
-        list_data = [x.strip() for x in str(self._parser.get("alias", "del", fallback="del")).split(",")]
-        self.delete.extend(list_data)
+        self.delete.extend(self.getlist("del", fallback="del"))
 
         logging.debug("%s: %s", self.section, self)
 
@@ -375,8 +374,8 @@ class SubCommands(BaseSection, CommandAttrs):
             outer (AppConfig): 設定クラスオブジェクト
         """
 
-        self._parser = outer._parser
-        self._section = outer._parser[self.section]
+        self.main_parser = outer.main_parser
+        self._section = outer.main_parser[self.section]
         self.default_reset()
         super().__init__(self)
 

--- a/libs/commands/registry/member.py
+++ b/libs/commands/registry/member.py
@@ -42,8 +42,9 @@ class MemberSection(BaseSection):
     guest_name: str
     """未登録メンバー名称"""
 
-    def __init__(self):
+    def __init__(self, outer: "AppConfig"):
         self.section = "member"
+        self.main_parser = outer.main_parser
         self._reset()
 
     def _reset(self):

--- a/libs/commands/registry/member.py
+++ b/libs/commands/registry/member.py
@@ -61,14 +61,13 @@ class MemberSection(BaseSection):
             outer (AppConfig): 設定クラスオブジェクト
         """
 
-        self._parser = outer._parser
         self._reset()
         super().__init__(
             self,
         )
 
         # 呼び出しキーワード取り込み
-        self.commandword = [x.strip() for x in self._parser.get(self.section, "commandword", fallback="メンバー一覧").split(",")]
+        self.commandword = self.getlist("commandword", fallback="メンバー一覧")
 
         logging.debug("%s: %s", self.section, self)
 

--- a/libs/commands/registry/team.py
+++ b/libs/commands/registry/team.py
@@ -40,8 +40,9 @@ class TeamSection(BaseSection):
     friendly_fire: bool
     """チームメイトが同卓しているゲームを集計対象に含めるか"""
 
-    def __init__(self):
+    def __init__(self, outer: "AppConfig"):
         self.section = "team"
+        self.main_parser = outer.main_parser
         self._reset()
 
     def _reset(self):

--- a/libs/commands/registry/team.py
+++ b/libs/commands/registry/team.py
@@ -59,12 +59,11 @@ class TeamSection(BaseSection):
             outer (AppConfig): 設定クラスオブジェクト
         """
 
-        self._parser = outer._parser
         self._reset()
         super().__init__(self)
 
         # 呼び出しキーワード取り込み
-        self.commandword = [x.strip() for x in self._parser.get(self.section, "commandword", fallback="チーム一覧").split(",")]
+        self.commandword = self.getlist("commandword", fallback="チーム一覧")
 
         logging.debug("%s: %s", self.section, self)
 


### PR DESCRIPTION
This pull request refactors the configuration handling across the codebase, replacing the use of the `_parser` attribute with a more explicit and consistent `main_parser` and `section_proxy` pattern. It also updates how configuration sections are initialized and accessed, improving clarity and maintainability. The changes affect multiple modules, including integration adapters, bootstrap configuration, and registry classes.

Configuration refactoring and consistency:

* Replaced `_parser` with `main_parser` in all config classes (`SvcConfig` for Discord, Slack, Standard IO, Web), ensuring consistent access to the main configuration parser. [[1]](diffhunk://#diff-9c24723dba3cb102da36ca782c93b643af26fab87a0ead8c7bce77107136bf65L48-R48) [[2]](diffhunk://#diff-4539bcd967bff69fc3046323ea8f50baa5061b27e03176b0bfb11820bfe47b0eL66-R66) [[3]](diffhunk://#diff-6231ae1fb0642cbe61463c971b1cf5ffb9ea6840abb9a7160e01ecb3f8ba4ebbL23-R23) [[4]](diffhunk://#diff-12a3093dc167bb1a88424a996519782e246388b37c15b0b9c11b67428b3d6e95L65-R65)
* Updated `BaseSection` and related mixins to use `main_parser` and `section_proxy`, and refactored all methods to access configuration values via `section_proxy` instead of `_section`. [[1]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cL29-R80) [[2]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cL86-R90) [[3]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cL97-R101) [[4]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cL176-R180) [[5]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cL266-R270) [[6]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cL352-R361) [[7]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cL378-R382)
* Refactored `AppConfig` to use `main_parser` throughout, removed `_parser`, and updated section initialization to pass `self` for context. [[1]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212R24-L48) [[2]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212L66-L79) [[3]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212L98-R157) [[4]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212L157-L158) [[5]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212L207-R226)

Integration and adapter updates:

* Modified adapter selection logic in `integrations/factory.py` to use `conf.main_parser` instead of casting to `_parser`, and cleaned up unnecessary imports. [[1]](diffhunk://#diff-a8d3389f8d5bf42a5293be9697fe2cc27cf858d988f3926604e7d54dbb77e596L5-L14) [[2]](diffhunk://#diff-a8d3389f8d5bf42a5293be9697fe2cc27cf858d988f3926604e7d54dbb77e596L49-R55)

Registry and section initialization improvements:

* Updated `MemberSection` and `TeamSection` classes to accept `outer: AppConfig` in their constructors, and refactored keyword loading to use the new `getlist` method for cleaner code. [[1]](diffhunk://#diff-0e3cabd708a159e090882ad6df087ebb438a78faf65d803150bd5d2b7a395029L45-R47) [[2]](diffhunk://#diff-0e3cabd708a159e090882ad6df087ebb438a78faf65d803150bd5d2b7a395029L63-R70) [[3]](diffhunk://#diff-e714f0a619367d58ae2d1b302e0bb27ab8aacd62d1dfd696d0ee1a6e42cbb7dcL43-R45) [[4]](diffhunk://#diff-e714f0a619367d58ae2d1b302e0bb27ab8aacd62d1dfd696d0ee1a6e42cbb7dcL61-R66)

Documentation and typing enhancements:

* Improved module docstrings and type hints for better clarity and maintainability. [[1]](diffhunk://#diff-89d8ede0504e55850185d055d5a095a633c48fc7862fd18360114cee421d433cL4-R6) [[2]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212L10-R10) [[3]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cL14-R14)

These changes collectively streamline configuration management, reduce ambiguity in parser usage, and make the codebase easier to understand and maintain.