### PR TITLE
Develop

### DIFF
--- a/integrations/discord/api.py
+++ b/integrations/discord/api.py
@@ -13,7 +13,7 @@ from table2ascii import PresetStyle, table2ascii
 
 import integrations.discord.events.audioop as _audioop
 from integrations.base.interface import APIInterface
-from integrations.protocols import CommandType
+from libs.domain.datamodels import CommandType
 from libs.types import StyleOptions
 from libs.utils import converter, formatter, textutil
 from libs.utils.timekit import Delimiter, Format

--- a/integrations/discord/events/handler.py
+++ b/integrations/discord/events/handler.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 import integrations.discord.events.audioop as _audioop
 import libs.dispatcher
-from integrations.protocols import MessageStatus
+from libs.domain.datamodels import MessageStatus
 
 if TYPE_CHECKING:
     from integrations.discord.adapter import ServiceAdapter

--- a/integrations/discord/parser.py
+++ b/integrations/discord/parser.py
@@ -9,7 +9,8 @@ from discord.channel import TextChannel
 
 import libs.global_value as g
 from integrations.base.interface import MessageParserDataMixin, MessageParserInterface
-from integrations.protocols import CommandType, MsgData, PostData, StatusData
+from integrations.protocols import MsgData, PostData, StatusData
+from libs.domain.datamodels import CommandType
 
 if TYPE_CHECKING:
     from integrations.discord.adapter import ServiceAdapter

--- a/integrations/protocols.py
+++ b/integrations/protocols.py
@@ -3,8 +3,9 @@ integrations/protocols.py
 """
 
 from dataclasses import dataclass, field, fields, is_dataclass
-from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Optional, Protocol
+
+from libs.domain.datamodels import ActionStatus, ChannelType, CommandType, MessageStatus
 
 if TYPE_CHECKING:
     from pathlib import Path  # noqa: F401
@@ -12,74 +13,6 @@ if TYPE_CHECKING:
     import pandas as pd  # noqa: F401
 
     from libs.types import MessageType, StyleOptions
-
-
-class MessageStatus(StrEnum):
-    """メッセージステータス"""
-
-    APPEND = "message_append"
-    """新規ポストイベント"""
-    CHANGED = "message_changed"
-    """編集イベント"""
-    DELETED = "message_deleted"
-    """削除イベント"""
-    DO_NOTHING = "do_nothing"
-    """何もしなくてよいイベント"""
-    UNDETERMINED = "undetermined"
-    """未定義状態"""
-
-
-class ChannelType(StrEnum):
-    """チャンネルタイプ"""
-
-    CHANNEL = "normal"
-    """通常チャンネル"""
-    PRIVATE = "private"
-    """プライベートチャンネル"""
-    DIRECT_MESSAGE = "direct_message"
-    """ダイレクトメッセージ"""
-    HOME_APP = "home_app"
-    """Slackのホームアプリ"""
-    SEARCH = "search_api"
-    """検索API"""
-    UNDETERMINED = "undetermined"
-    """未定義状態"""
-
-
-class CommandType(StrEnum):
-    """実行(する/した)サブコマンド"""
-
-    RESULTS = "results"
-    """成績サマリ"""
-    GRAPH = "graph"
-    """グラフ生成"""
-    RANKING = "ranking"
-    """ランキング"""
-    RATING = "rating"
-    """レーティング"""
-    REPORT = "report"
-    """レポート"""
-    MEMBER_LIST = "member"
-    """メンバー一覧"""
-    TEAM_LIST = "team"
-    """チーム一覧"""
-    HELP = "help"
-    """ヘルプ"""
-    COMPARISON = "comparison"
-    """突合処理"""
-    UNKNOWN = "unknown"
-    """未定義"""
-
-
-class ActionStatus(StrEnum):
-    """DBに対する操作"""
-
-    CHANGE = "change"
-    """insert/updateが実行された"""
-    DELETE = "delete"
-    """deleteが実行された"""
-    NOTHING = "nothing"
-    """何もしてない"""
 
 
 class DataMixin:

--- a/integrations/slack/events/home_tab/personal.py
+++ b/integrations/slack/events/home_tab/personal.py
@@ -6,11 +6,11 @@ import logging
 from typing import TYPE_CHECKING, cast
 
 import libs.global_value as g
-from integrations.protocols import CommandType
 from integrations.slack.adapter import ServiceAdapter
 from integrations.slack.events.handler_registry import register
 from integrations.slack.events.home_tab import ui_parts
 from libs.commands.results import detail
+from libs.domain.datamodels import CommandType
 from libs.utils import dictutil
 from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/integrations/slack/events/home_tab/ranking.py
+++ b/integrations/slack/events/home_tab/ranking.py
@@ -6,11 +6,11 @@ import logging
 from typing import TYPE_CHECKING, cast
 
 import libs.global_value as g
-from integrations.protocols import CommandType
 from integrations.slack.adapter import ServiceAdapter
 from integrations.slack.events.handler_registry import register
 from integrations.slack.events.home_tab import ui_parts
 from libs.commands.ranking import ranking
+from libs.domain.datamodels import CommandType
 from libs.utils import dictutil
 from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/integrations/slack/events/home_tab/summary.py
+++ b/integrations/slack/events/home_tab/summary.py
@@ -6,13 +6,13 @@ import logging
 from typing import TYPE_CHECKING, cast
 
 import libs.global_value as g
-from integrations.protocols import CommandType
 from integrations.slack.adapter import ServiceAdapter
 from integrations.slack.events.handler_registry import register
 from integrations.slack.events.home_tab import ui_parts
 from libs.commands.graph import summary as graph_summary
 from libs.commands.ranking import rating
 from libs.commands.results import summary as results_summary
+from libs.domain.datamodels import CommandType
 from libs.utils import dictutil
 from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/integrations/slack/events/home_tab/versus.py
+++ b/integrations/slack/events/home_tab/versus.py
@@ -6,11 +6,11 @@ import logging
 from typing import TYPE_CHECKING, cast
 
 import libs.global_value as g
-from integrations.protocols import CommandType
 from integrations.slack.adapter import ServiceAdapter
 from integrations.slack.events.handler_registry import register
 from integrations.slack.events.home_tab import ui_parts
 from libs.commands.results import versus
+from libs.domain.datamodels import CommandType
 from libs.utils import dictutil
 from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/integrations/slack/parser.py
+++ b/integrations/slack/parser.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING, cast
 
 import libs.global_value as g
 from integrations.base.interface import MessageParserDataMixin, MessageParserInterface
-from integrations.protocols import ChannelType, CommandType, MessageStatus, MsgData, PostData, StatusData
+from integrations.protocols import MsgData, PostData, StatusData
+from libs.domain.datamodels import ChannelType, CommandType, MessageStatus
 
 if TYPE_CHECKING:
     from integrations.slack.adapter import ServiceAdapter

--- a/integrations/standard_io/parser.py
+++ b/integrations/standard_io/parser.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from typing import cast
 
 from integrations.base.interface import MessageParserDataMixin, MessageParserInterface
-from integrations.protocols import ChannelType, MessageStatus, MsgData, PostData, StatusData
+from integrations.protocols import MsgData, PostData, StatusData
+from libs.domain.datamodels import ChannelType, MessageStatus
 
 
 class MessageParser(MessageParserDataMixin, MessageParserInterface):

--- a/integrations/web/parser.py
+++ b/integrations/web/parser.py
@@ -3,7 +3,8 @@ integrations/web/parser.py
 """
 
 from integrations.base.interface import MessageParserDataMixin, MessageParserInterface
-from integrations.protocols import MessageStatus, MsgData, PostData, StatusData
+from integrations.protocols import MsgData, PostData, StatusData
+from libs.domain.datamodels import MessageStatus
 
 
 class MessageParser(MessageParserDataMixin, MessageParserInterface):

--- a/libs/commands/graph/entry.py
+++ b/libs/commands/graph/entry.py
@@ -5,9 +5,9 @@ libs/commands/graph/entry.py
 from typing import TYPE_CHECKING
 
 import libs.global_value as g
-from integrations.protocols import CommandType
 from libs.bootstrap.section import SubCommands
 from libs.commands.graph import personal, rating, summary
+from libs.domain.datamodels import CommandType
 from libs.utils import dictutil
 
 if TYPE_CHECKING:

--- a/libs/commands/help/entry.py
+++ b/libs/commands/help/entry.py
@@ -6,9 +6,9 @@ import textwrap
 from typing import TYPE_CHECKING, cast
 
 import libs.global_value as g
-from integrations.protocols import CommandType
 from libs.bootstrap.section import SubCommands
 from libs.data import lookup
+from libs.domain.datamodels import CommandType
 from libs.types import StyleOptions
 from libs.utils import dictutil
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/libs/commands/ranking/entry.py
+++ b/libs/commands/ranking/entry.py
@@ -5,9 +5,9 @@ libs/commands/ranking/entry.py
 from typing import TYPE_CHECKING
 
 import libs.global_value as g
-from integrations.protocols import CommandType
 from libs.bootstrap.section import SubCommands
 from libs.commands.ranking import ranking, rating
+from libs.domain.datamodels import CommandType
 from libs.utils import dictutil
 
 if TYPE_CHECKING:

--- a/libs/commands/ranking/rating.py
+++ b/libs/commands/ranking/rating.py
@@ -7,9 +7,8 @@ from typing import TYPE_CHECKING
 import pandas as pd
 
 import libs.global_value as g
-from integrations.protocols import CommandType
 from libs.data import aggregate, loader
-from libs.domain.datamodels import GameInfo
+from libs.domain.datamodels import CommandType, GameInfo
 from libs.functions import message
 from libs.functions.compose import badge
 from libs.types import StyleOptions

--- a/libs/commands/registry/member.py
+++ b/libs/commands/registry/member.py
@@ -6,9 +6,9 @@ import logging
 from typing import TYPE_CHECKING, TypedDict, cast
 
 import libs.global_value as g
-from integrations.protocols import CommandType
 from libs.bootstrap.app_config import BaseSection
 from libs.data import loader, modify
+from libs.domain.datamodels import CommandType
 from libs.utils import dbutil, textutil, validator
 
 if TYPE_CHECKING:

--- a/libs/commands/registry/team.py
+++ b/libs/commands/registry/team.py
@@ -6,9 +6,9 @@ import logging
 from typing import TYPE_CHECKING, TypedDict, cast
 
 import libs.global_value as g
-from integrations.protocols import CommandType
 from libs.bootstrap.app_config import BaseSection
 from libs.data import initialization, loader, modify
+from libs.domain.datamodels import CommandType
 from libs.utils import dbutil, formatter, textutil, validator
 
 if TYPE_CHECKING:

--- a/libs/commands/report/entry.py
+++ b/libs/commands/report/entry.py
@@ -5,9 +5,9 @@ libs/commands/report/entry.py
 from typing import TYPE_CHECKING
 
 import libs.global_value as g
-from integrations.protocols import CommandType
 from libs.bootstrap.section import SubCommands
 from libs.commands.report import matrix, monthly, stats_list, stats_report, winner
+from libs.domain.datamodels import CommandType
 from libs.utils import dictutil
 
 if TYPE_CHECKING:

--- a/libs/commands/results/entry.py
+++ b/libs/commands/results/entry.py
@@ -5,9 +5,9 @@ libs/commands/results/entry.py
 from typing import TYPE_CHECKING
 
 import libs.global_value as g
-from integrations.protocols import CommandType
 from libs.bootstrap.section import SubCommands
 from libs.commands.results import detail, summary, versus
+from libs.domain.datamodels import CommandType
 from libs.utils import dictutil
 
 if TYPE_CHECKING:

--- a/libs/data/lookup.py
+++ b/libs/data/lookup.py
@@ -249,7 +249,6 @@ def resolve_commands(rule_version: str, command_type: CommandType) -> list[str]:
         case _:
             return []
 
-    print(">>>", commandwords)
     return [x for x in g.keyword_dispatcher if x in commandwords]
 
 

--- a/libs/data/modify.py
+++ b/libs/data/modify.py
@@ -11,8 +11,8 @@ from contextlib import closing
 from typing import TYPE_CHECKING, cast
 
 import libs.global_value as g
-from integrations.protocols import ActionStatus, MessageStatus
 from libs.data import lookup
+from libs.domain.datamodels import ActionStatus, MessageStatus
 from libs.functions import message
 from libs.types import StyleOptions
 from libs.utils import dbutil, formatter

--- a/libs/dispatcher.py
+++ b/libs/dispatcher.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING
 
 import libs.global_value as g
 from integrations import factory
-from integrations.protocols import MessageStatus
 from libs.data import lookup, modify
+from libs.domain.datamodels import MessageStatus
 from libs.domain.score import GameResult
 from libs.functions import message
 from libs.types import StyleOptions

--- a/libs/domain/datamodels.py
+++ b/libs/domain/datamodels.py
@@ -1,9 +1,10 @@
 """
-libs/domain/command.py
+libs/domain/datamodels.py
 """
 
 import logging
 from dataclasses import dataclass, field
+from enum import StrEnum
 from math import ceil
 from typing import TYPE_CHECKING, Literal, Optional, Union
 
@@ -16,6 +17,74 @@ if TYPE_CHECKING:
     from integrations.base.interface import MessageParserProtocol
     from libs.domain.score import GameResult
     from libs.types import RemarkDict
+
+
+class CommandType(StrEnum):
+    """実行(する/した)サブコマンド"""
+
+    RESULTS = "results"
+    """成績サマリ"""
+    GRAPH = "graph"
+    """グラフ生成"""
+    RANKING = "ranking"
+    """ランキング"""
+    RATING = "rating"
+    """レーティング"""
+    REPORT = "report"
+    """レポート"""
+    MEMBER_LIST = "member"
+    """メンバー一覧"""
+    TEAM_LIST = "team"
+    """チーム一覧"""
+    HELP = "help"
+    """ヘルプ"""
+    COMPARISON = "comparison"
+    """突合処理"""
+    UNKNOWN = "unknown"
+    """未定義"""
+
+
+class MessageStatus(StrEnum):
+    """メッセージステータス"""
+
+    APPEND = "message_append"
+    """新規ポストイベント"""
+    CHANGED = "message_changed"
+    """編集イベント"""
+    DELETED = "message_deleted"
+    """削除イベント"""
+    DO_NOTHING = "do_nothing"
+    """何もしなくてよいイベント"""
+    UNDETERMINED = "undetermined"
+    """未定義状態"""
+
+
+class ActionStatus(StrEnum):
+    """DBに対する操作"""
+
+    CHANGE = "change"
+    """insert/updateが実行された"""
+    DELETE = "delete"
+    """deleteが実行された"""
+    NOTHING = "nothing"
+    """何もしてない"""
+
+
+class ChannelType(StrEnum):
+    """チャンネルタイプ"""
+
+    CHANNEL = "normal"
+    """通常チャンネル"""
+    PRIVATE = "private"
+    """プライベートチャンネル"""
+    DIRECT_MESSAGE = "direct_message"
+    """ダイレクトメッセージ"""
+    HOME_APP = "home_app"
+    """Slackのホームアプリ"""
+    SEARCH = "search_api"
+    """検索API"""
+    UNDETERMINED = "undetermined"
+    """未定義状態"""
 
 
 @dataclass

--- a/libs/functions/message.py
+++ b/libs/functions/message.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import libs.global_value as g
-from integrations.protocols import CommandType
+from libs.domain.datamodels import CommandType
 from libs.functions.compose import text_item
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 from libs.utils.timekit import Format

--- a/tests/events/test_message_dispatch.py
+++ b/tests/events/test_message_dispatch.py
@@ -10,8 +10,8 @@ import pytest
 import libs.dispatcher
 import libs.global_value as g
 from integrations import factory
-from integrations.protocols import MessageStatus
 from libs.bootstrap import configuration
+from libs.domain.datamodels import MessageStatus
 from tests.events import param_data
 
 


### PR DESCRIPTION
This pull request refactors the codebase to centralize and standardize the definitions of several key enums (`CommandType`, `ChannelType`, `MessageStatus`, `ActionStatus`) by moving them from `integrations/protocols.py` to `libs/domain/datamodels.py`. As a result, all imports throughout the codebase are updated to reference the new location. This improves maintainability and clarity by consolidating domain models in a single module and removing redundant definitions.

Centralization of domain enums:

* Removed the definitions of `CommandType`, `ChannelType`, `MessageStatus`, and `ActionStatus` from `integrations/protocols.py` and replaced them with imports from `libs/domain/datamodels.py`.
* Updated all imports in Discord, Slack, and Standard IO integration files to reference these enums from `libs/domain/datamodels.py` instead of `integrations/protocols.py`. [[1]](diffhunk://#diff-e70f2c4ac2e5530abf5bae8dede764a1abe586aec1781fb4dd21c822d3828c7bL16-R16) [[2]](diffhunk://#diff-370bd60fbc83a3f76ea9b745e643db23053f78d2dccbec800b05b5b8d570610aL12-R12) [[3]](diffhunk://#diff-6d058926728a6b11a635dd4b83e5f144b17c3cd4a12b41681963950479211475L12-R13) [[4]](diffhunk://#diff-110dedcbd8762e9c4a5c1def1ed8cc7f118adb2a8afce710c68a6047b5c12c9dL9-R13) [[5]](diffhunk://#diff-98fec2643e2da9d619885c3254256a2914a1bfcc9eecf8d91bab5c084d074155L9-R13) [[6]](diffhunk://#diff-8c2643c908331a43430aedfa9a5c3f006959b1c0c29feb975cf45ece8830b8d7L9-R15) [[7]](diffhunk://#diff-23baa78319a7052e993f6ca661ab309cf3f43dbcdf2e2ab0782ddb859f0adec0L9-R13) [[8]](diffhunk://#diff-8210fd02189a56ec626b50250ffecb24f0cc98ce16b46ebda41721243e282e97L10-R11) [[9]](diffhunk://#diff-58cb6902680c277861a8021d722f188a8ee3ef2b7c201c92d9c1741557064801L9-R10) [[10]](diffhunk://#diff-71cf0b9208fa1de0ffc21d156583a474052dc4cea442282efe13380f4464a71bL6-R7)

Refactoring command-related modules:

* Updated command entry and registry modules to import `CommandType` from `libs/domain/datamodels.py` for consistency. [[1]](diffhunk://#diff-b8cb47706451cf132fb00329d13f047e7ea10fcfd76e7a420d814588dde033deL8-R10) [[2]](diffhunk://#diff-50f3210c9b6448a619d76ec07b7b40c0cb71eb9866414548f005c8c0b0c62dc9L9-R11) [[3]](diffhunk://#diff-6e7de3e653827fa05b18ac4acb781fad85e3b92ee540c0b5808b96f31b02290dL8-R10) [[4]](diffhunk://#diff-d73d0a7e72076fc61271e89b75bfc820a564285825bf8133a2d20a64b326cf32L10-R11) [[5]](diffhunk://#diff-0e3cabd708a159e090882ad6df087ebb438a78faf65d803150bd5d2b7a395029L9-R11) [[6]](diffhunk://#diff-e714f0a619367d58ae2d1b302e0bb27ab8aacd62d1dfd696d0ee1a6e42cbb7dcL9-R11) [[7]](diffhunk://#diff-bc02d231488604bbfc1df0ddf38c57465c911a51b8e818b8ba5dab4ab8929f77L8-R10) [[8]](diffhunk://#diff-6b1a16063303e31de3584d2fb77a7dbf73d965b6bb14e0c1c37b4c79bededc10L8-R10)

Minor cleanup:

* Removed a debug print statement from `libs/data/lookup.py` for cleaner output.