### PR TITLE
Develop

### DIFF
--- a/libs/bootstrap/app_config.py
+++ b/libs/bootstrap/app_config.py
@@ -23,8 +23,6 @@ from libs.domain.rule import RuleSet
 from libs.types import GradeTableDict
 
 if TYPE_CHECKING:
-    from configparser import SectionProxy
-
     from libs.bootstrap.section import SubCommands
     from libs.types import PlaceholderDict
 
@@ -32,9 +30,6 @@ if TYPE_CHECKING:
 class DropItems(BaseSection):
     """非表示項目リスト"""
 
-    section: str
-    main_parser: ConfigParser
-    section_proxy: "SectionProxy"
     results: set[str]
     """成績サマリ非表示項目"""
     ranking: set[str]
@@ -83,16 +78,15 @@ class BadgeDisplay(BaseSection):
         table_name: str = field(default=str())
         table: GradeTableDict = field(default_factory=GradeTableDict)
 
-    section: str
-    main_parser: ConfigParser
-    section_proxy: "SectionProxy"
     grade: "BadgeGradeSpec" = BadgeGradeSpec()
+    """段位情報"""
 
     def __init__(self, outer: "AppConfig"):
         self.section = "grade"
         self.main_parser = outer.main_parser
+        super().__init__(self)
 
-        self.grade.table_name = self.main_parser.get(self.section, "table_name", fallback="")
+        self.grade.table_name = self.get("table_name", fallback="")
 
 
 class AppConfig:
@@ -252,9 +246,9 @@ class AppConfig:
         protected_values: Union[str, list]
         match section_name:
             case "setting":
-                protected_values = self.setting.help  # 上書き保護
+                protected_values = self.setting.remarks_word  # 上書き保護
                 self.setting.config_load(self)
-                self.setting.help = protected_values
+                self.setting.remarks_word = protected_values
             case "results":
                 protected_values = self.results.commandword  # 上書き保護
                 self.results.config_load(self)

--- a/libs/bootstrap/app_config.py
+++ b/libs/bootstrap/app_config.py
@@ -18,6 +18,7 @@ from libs.commands.registry.team import TeamSection
 from libs.commands.report.entry import ReportConfig
 from libs.commands.results.entry import ResultsConfig
 from libs.data.lookup import read_memberslist
+from libs.domain.datamodels import CommandType
 from libs.domain.rule import RuleSet
 from libs.types import GradeTableDict
 
@@ -192,20 +193,33 @@ class AppConfig:
         self.report.config_load(self)
         self.help.config_load(self)
 
-    def word_list(self) -> list[str]:
+    def word_list(self, add_words: list | None = None) -> list[str]:
         """設定されている値、キーワードをリスト化する
+
+        Args:
+            add_words (list | None, optional): リストに追加するワード. Defaults to None.
 
         Returns:
             list: リスト化されたキーワード
         """
 
         words: list[str] = []
-        words.extend(self.results.commandword)
-        words.extend(self.graph.commandword)
-        words.extend(self.ranking.commandword)
-        words.extend(self.report.commandword)
+
+        if add_words:
+            words.extend(add_words)
+
         words.extend(list(self.rule.keyword_mapping.keys()))
         words.extend([self.setting.remarks_word])
+
+        for command_name in CommandType:
+            if hasattr(self, str(command_name)):
+                command = getattr(self, str(command_name))
+                if hasattr(command, "default_commandword"):
+                    words.append(command.default_commandword)
+                if hasattr(command, "commandword"):
+                    words.extend(command.commandword)
+                if hasattr(command, "command_suffix"):
+                    words.extend(command.command_suffix)
 
         for k, v in self.alias.to_dict().items():
             if isinstance(v, list):

--- a/libs/bootstrap/app_config.py
+++ b/libs/bootstrap/app_config.py
@@ -84,9 +84,10 @@ class BadgeDisplay(BaseSection):
     def __init__(self, outer: "AppConfig"):
         self.section = "grade"
         self.main_parser = outer.main_parser
-        super().__init__(self)
 
-        self.grade.table_name = self.get("table_name", fallback="")
+        if self.main_parser.has_section(self.section):
+            self.section_proxy = self.main_parser[self.section]
+            self.grade.table_name = self.get("table_name", fallback="")
 
 
 class AppConfig:

--- a/libs/bootstrap/app_config.py
+++ b/libs/bootstrap/app_config.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from configparser import SectionProxy
 
     from libs.bootstrap.section import SubCommands
+    from libs.types import PlaceholderDict
 
 
 class DropItems(BaseSection):
@@ -273,11 +274,12 @@ class AppConfig:
             case _:
                 return
 
-    def read_channel_config(self, section_name: str) -> Optional[Path]:
+    def read_channel_config(self, section_name: str, ret_dict: "PlaceholderDict") -> Optional[Path]:
         """チャンネル個別設定読み込み
 
         Args:
-            section_name (str): セクション名
+            section_name (str): チャンネル個別設定セクション名
+            ret_dict (PlaceholderDict): パラメータ
 
         Returns:
             Optional[Path]: 個別設定読み込み結果
@@ -289,6 +291,8 @@ class AppConfig:
         self.initialization()
 
         if self.main_parser.has_section(section_name):
+            if default_rule := self.main_parser[section_name].get("default_rule"):
+                ret_dict.update({"default_rule": default_rule})
             if channel_config := self.main_parser[section_name].get("channel_config"):
                 config_path = Path(channel_config)
                 if config_path.exists():

--- a/libs/bootstrap/configuration.py
+++ b/libs/bootstrap/configuration.py
@@ -277,14 +277,31 @@ def setup(init_db: bool = True):
     initialization.main(init_db)
     lookup.read_memberslist()
 
+    register()
+
+    # メモ記録ワード登録
+    if g.cfg.setting.remarks_suffix:
+        for rule_version in g.cfg.rule.rule_list:
+            keywords = [word for word, rule in g.cfg.rule.keyword_mapping.items() if rule == rule_version]
+            if keywords:
+                g.cfg.rule.data[rule_version].remarks_words.extend([f"{rule}{suffix}" for rule in keywords for suffix in g.cfg.setting.remarks_suffix])
+    else:
+        for rule_version in g.cfg.rule.rule_list:
+            g.cfg.rule.data[rule_version].remarks_words.append(g.cfg.setting.remarks_word)
+
     # キーワード重複チェック
     g.cfg.rule.check(
-        chk_commands=set(g.cfg.results.commandword + g.cfg.graph.commandword + g.cfg.ranking.commandword + g.cfg.report.commandword),
+        chk_commands=set(
+            g.cfg.results.commandword
+            + g.cfg.graph.commandword
+            + g.cfg.ranking.commandword
+            + g.cfg.report.commandword
+            + g.cfg.help.commandword
+            + list(g.keyword_dispatcher)
+        ),
         chk_members=set(lookup.enumeration_all_members()),
         default_rule=g.cfg.setting.default_rule,
     )
-
-    register()
 
 
 def register():

--- a/libs/bootstrap/section.py
+++ b/libs/bootstrap/section.py
@@ -209,6 +209,8 @@ class SettingSection(BaseSection):
     """成績記録キーワード(プライマリ)"""
     remarks_word: str
     """メモ記録用キーワード"""
+    remarks_suffix: list[str]
+    """メモ記録用キーワードサフィックス"""
     rule_config: Path
     """ルール設定ファイル"""
     default_rule: str
@@ -243,9 +245,9 @@ class SettingSection(BaseSection):
         self._reset()
 
     def _reset(self):
-        self.help = str("麻雀成績ヘルプ")
         self.keyword = str("終局")
-        self.remarks_word = str("麻雀成績メモ")
+        self.remarks_word = str("麻雀メモ")
+        self.remarks_suffix = []
         self.rule_config = Path("files/default_rule.ini")
         self.time_adjust = int(12)
         self.default_rule = str("")
@@ -304,7 +306,6 @@ class SettingSection(BaseSection):
 class AliasSection(BaseSection):
     """aliasセクション処理"""
 
-    section: str
     results: list
     """成績サマリ出力コマンド"""
     graph: list
@@ -366,8 +367,6 @@ class AliasSection(BaseSection):
 class SubCommands(BaseSection, CommandAttrs):
     """サブコマンドセクション処理"""
 
-    section: str
-    """読み込みセクション"""
     default_commandword: str
     """コマンドワードデフォルト値"""
 

--- a/libs/commands/help/entry.py
+++ b/libs/commands/help/entry.py
@@ -59,26 +59,26 @@ def help_message(m: "MessageParserProtocol"):
     rule_version = g.params.get("default_rule", g.cfg.mahjong.rule_version)
 
     m.set_message(
-        "使い方：<呼び出しキーワード> [検索範囲] [対象メンバー] [オプション]",
+        "使い方：<呼び出しワード> [検索範囲] [対象メンバー] [オプション]",
         StyleOptions(title="機能呼び出し"),
     )
     m.set_message(
         textwrap.dedent(f"""\
-        呼び出しキーワード：{"、".join(lookup.resolve_commands(rule_version, CommandType.RESULTS))}
+        呼び出しワード：{"、".join(lookup.resolve_commands(rule_version, CommandType.RESULTS))}
         検索範囲デフォルト：{g.cfg.results.aggregation_range}
         """),
         StyleOptions(title="成績サマリ", indent=1, sub_title=True),
     )
     m.set_message(
         textwrap.dedent(f"""\
-        呼び出しキーワード：{"、".join(lookup.resolve_commands(rule_version, CommandType.GRAPH))}
+        呼び出しワード：{"、".join(lookup.resolve_commands(rule_version, CommandType.GRAPH))}
         検索範囲デフォルト：{g.cfg.graph.aggregation_range}
         """),
         StyleOptions(title="成績グラフ", indent=1, sub_title=True),
     )
     m.set_message(
         textwrap.dedent(f"""\
-        呼び出しキーワード：{"、".join(lookup.resolve_commands(rule_version, CommandType.RANKING))}
+        呼び出しワード：{"、".join(lookup.resolve_commands(rule_version, CommandType.RANKING))}
         検索範囲デフォルト：{g.cfg.ranking.aggregation_range}
         規定打数デフォルト：全体ゲーム数 × {g.cfg.ranking.stipulated_rate} ＋ 1
         出力制限デフォルト：上位 {g.cfg.ranking.ranked} 名
@@ -87,22 +87,22 @@ def help_message(m: "MessageParserProtocol"):
     )
     m.set_message(
         textwrap.dedent(f"""\
-        呼び出しキーワード：{"、".join(lookup.resolve_commands(rule_version, CommandType.REPORT))}
+        呼び出しワード：{"、".join(lookup.resolve_commands(rule_version, CommandType.REPORT))}
         検索範囲デフォルト：{g.cfg.report.aggregation_range}
         """),
         StyleOptions(title="レポート", indent=1, sub_title=True),
     )
     m.set_message(
-        f"呼び出しキーワード：{'、'.join(lookup.resolve_commands(rule_version, CommandType.MEMBER_LIST))}",
+        f"呼び出しワード：{'、'.join(lookup.resolve_commands(rule_version, CommandType.MEMBER_LIST))}",
         StyleOptions(title="メンバー一覧", indent=1, sub_title=True),
     )
     m.set_message(
-        f"呼び出しキーワード：{'、'.join(lookup.resolve_commands(rule_version, CommandType.TEAM_LIST))}",
+        f"呼び出しワード：{'、'.join(lookup.resolve_commands(rule_version, CommandType.TEAM_LIST))}",
         StyleOptions(title="チーム一覧", indent=1, sub_title=True),
     )
     m.set_message(  # 検索範囲
         ExtDt.print_range(),
-        StyleOptions(title="検索範囲に指定できるキーワード"),
+        StyleOptions(title="検索範囲に指定できるワード"),
     )
 
     # メモ機能
@@ -122,8 +122,8 @@ def help_message(m: "MessageParserProtocol"):
 
     m.set_message(
         textwrap.dedent(f"""\
-        使い方：<登録キーワード> <対象メンバー> <登録ワード>
-        登録キーワード：{g.cfg.setting.remarks_word}
+        使い方：<メモ記録ワード> <対象メンバー> <内容>
+        メモ記録ワード：{g.cfg.setting.remarks_word}
 
         {remarks_type1}
         {remarks_type0}
@@ -134,7 +134,7 @@ def help_message(m: "MessageParserProtocol"):
     # ルールセット
     m.set_message(
         g.cfg.rule.print(str(g.params.get("default_rule"))),
-        StyleOptions(title="ルールセット"),
+        StyleOptions(title="ルールセット情報"),
     )
 
     # レギュレーション

--- a/libs/commands/help/entry.py
+++ b/libs/commands/help/entry.py
@@ -56,7 +56,7 @@ def help_message(m: "MessageParserProtocol"):
     )
     g.cfg.rule.status_update(cast(dict, g.params))
 
-    rule_version = g.params.get("default_rule", g.cfg.mahjong.rule_version)
+    rule_version = g.params.get("rule_version", g.cfg.setting.default_rule)
 
     m.set_message(
         "使い方：<呼び出しワード> [検索範囲] [対象メンバー] [オプション]",
@@ -107,14 +107,14 @@ def help_message(m: "MessageParserProtocol"):
 
     # メモ機能
     remarks_type1: str = ""
-    if words := lookup.regulation_list(1):
+    if words := lookup.regulation_list(1, rule_version):
         remarks_type1 += "個別カウントワード：" + "、".join(words)
     else:
         if g.cfg.rule.get_undefined_word(str(g.params.get("default_rule"))) == 1:
             remarks_type1 += "個別カウントワード：未登録ワードのすべてを個別にカウント"
 
     remarks_type0: str = ""
-    if words := lookup.regulation_list(0):
+    if words := lookup.regulation_list(0, rule_version):
         remarks_type0 += "役満カウントワード：" + "、".join(words)
     else:
         if g.cfg.rule.get_undefined_word(str(g.params.get("default_rule"))) == 0:
@@ -123,7 +123,7 @@ def help_message(m: "MessageParserProtocol"):
     m.set_message(
         textwrap.dedent(f"""\
         使い方：<メモ記録ワード> <対象メンバー> <内容>
-        メモ記録ワード：{g.cfg.setting.remarks_word}
+        メモ記録ワード：{"、".join(g.cfg.rule.data[rule_version].remarks_words)}
 
         {remarks_type1}
         {remarks_type0}
@@ -133,19 +133,19 @@ def help_message(m: "MessageParserProtocol"):
 
     # ルールセット
     m.set_message(
-        g.cfg.rule.print(str(g.params.get("default_rule"))),
+        g.cfg.rule.print(rule_version),
         StyleOptions(title="ルールセット情報"),
     )
 
     # レギュレーション
     regulation: str = ""
-    if words := lookup.regulation_list(2):
+    if words := lookup.regulation_list(2, rule_version):
         regulation += "卓外清算ワード(個人)：\n"
         for word in words:
             regulation += f"\t{word}\n"
         regulation += "\n"
 
-    if words := lookup.regulation_list(3):
+    if words := lookup.regulation_list(3, rule_version):
         regulation += "卓外清算ワード(チーム)：\n"
         for word in words:
             regulation += f"\t{word}\n"

--- a/libs/commands/registry/member.py
+++ b/libs/commands/registry/member.py
@@ -83,9 +83,7 @@ class MemberSection(BaseSection):
         """
 
         self._reset()
-        super().__init__(
-            self,
-        )
+        super().__init__(self)
 
         # 呼び出しキーワード取り込み
         self.commandword = self.getlist("commandword", fallback=self.default_commandword)

--- a/libs/commands/results/summary.py
+++ b/libs/commands/results/summary.py
@@ -30,6 +30,11 @@ def aggregation(m: "MessageParserProtocol"):
     df_game = loader.read_data("SUMMARY_DETAILS")
     df_remarks = loader.read_data("REMARKS_INFO")
 
+    current_rule: str = ""
+    if rule_set := g.params.get("rule_set"):
+        for rule in rule_set.values():
+            current_rule = rule
+
     # インデックスの振りなおし
     df_summary.reset_index(inplace=True, drop=True)
     df_summary.index += 1
@@ -46,7 +51,8 @@ def aggregation(m: "MessageParserProtocol"):
     else:  # チーム集計
         headline_title = "チーム成績サマリ"
 
-    add_text = "" if g.params.get("ignore_flying") else f" / トバされた人（延べ）：{df_summary['flying'].sum()} 人"
+    # ルール別
+    add_text = "" if g.cfg.rule.get_ignore_flying(current_rule) else f" / トバされた人（延べ）：{df_summary['flying'].sum()} 人"
     header_text = message.header(game_info, m, add_text, 1)
     m.set_headline(header_text, StyleOptions(title=headline_title))
 
@@ -86,7 +92,7 @@ def aggregation(m: "MessageParserProtocol"):
         "flying",
     ]
 
-    if g.params.get("ignore_flying") or g.cfg.dropitems.results & g.cfg.dropitems.flying:  # トビカウントなし
+    if g.cfg.rule.get_ignore_flying(current_rule) or g.cfg.dropitems.results & g.cfg.dropitems.flying:  # トビカウントなし
         header_list.remove("flying")
         filter_list.remove("flying")
 

--- a/libs/data/loader.py
+++ b/libs/data/loader.py
@@ -80,7 +80,7 @@ def read_data(keyword: str, params: dict = {}) -> pd.DataFrame:
         params = cast(dict, g.params)
 
     if "mode" not in params:
-        mode = g.cfg.rule.get_mode(g.cfg.mahjong.rule_version)
+        mode = g.cfg.rule.get_mode(g.cfg.setting.default_rule)
         params.update({"mode": mode if mode else 4})
     if starttime := params.get("starttime"):
         params.update({"starttime": cast("ExtDt", starttime).format(Format.SQL)})

--- a/libs/data/lookup.py
+++ b/libs/data/lookup.py
@@ -196,7 +196,7 @@ def regulation_list(word_type: int = 0, rule_version: str | None = None) -> list
     for word, ex_point in rows:
         if ex_point:
             point = f"{ex_point:.1f}".replace("-", "▲")
-            ret.append(f"{word}:{point}pt")
+            ret.append(f"{word}\t{point}pt")
         else:
             ret.append(f"{word}")
 

--- a/libs/dispatcher.py
+++ b/libs/dispatcher.py
@@ -88,7 +88,7 @@ def other_words(word: str, m: "MessageParserProtocol"):
         m (MessageParserProtocol): メッセージデータ
     """
 
-    if re.match(rf"^{g.cfg.setting.remarks_word}$", word) and m.in_thread:  # 追加メモ
+    if word in g.cfg.rule.remarks_words and m.in_thread:  # 追加メモ
         if lookup.exsist_record(m.data.thread_ts).has_valid_data():
             modify.check_remarks(m)
     else:  # スコア登録

--- a/libs/dispatcher.py
+++ b/libs/dispatcher.py
@@ -25,7 +25,7 @@ def by_keyword(m: "MessageParserProtocol"):
     # チャンネル個別設定切替
     g.params.update(
         {
-            "channel_config": g.cfg.read_channel_config(m.status.source),
+            "channel_config": g.cfg.read_channel_config(m.status.source, g.params),
             "source": g.cfg.resolve_channel_id(m.status.source),
             "separate": lookup.resolve_separate_flag(m),
         }

--- a/libs/domain/datamodels.py
+++ b/libs/domain/datamodels.py
@@ -188,7 +188,7 @@ class GameInfo:
 
         # グローバルパラメータチェック
         if "rule_version" not in g.params:
-            g.params.update({"rule_version": g.cfg.mahjong.rule_version})
+            g.params.update({"rule_version": g.cfg.setting.default_rule})
         if "starttime" not in g.params:
             g.params.update({"starttime": ExtDt().range("全部").start})
         if "endtime" not in g.params:

--- a/libs/domain/datamodels.py
+++ b/libs/domain/datamodels.py
@@ -3,7 +3,7 @@ libs/domain/datamodels.py
 """
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import MISSING, dataclass, field, fields
 from enum import StrEnum
 from math import ceil
 from typing import TYPE_CHECKING, Literal, Optional, Union
@@ -91,86 +91,66 @@ class ChannelType(StrEnum):
 class CommandAttrs:
     """サブコマンド設定パラメータ"""
 
-    commandword: list[str]
+    commandword: list[str] = field(default_factory=list)
     """呼び出しキーワード"""
-    command_suffix: list[str]
+    command_suffix: list[str] = field(default_factory=list)
     """コマンド接尾辞(登録キーワード+接尾辞を呼び出しキーワードとして扱う)"""
-    aggregation_range: str
+    aggregation_range: str = field(default="当日")
     """検索範囲未指定時に使用される範囲"""
-    individual: bool
+    individual: bool = field(default=True)
     """個人/チーム集計切替フラグ
     - *True*: 個人集計
     - *False*: チーム集計
     """
-    all_player: bool
-    daily: bool
-    fourfold: bool
-    game_results: bool
-    guest_skip: bool
+    all_player: bool = field(default=False)
+    daily: bool = field(default=True)
+    fourfold: bool = field(default=True)
+    game_results: bool = field(default=False)
+    guest_skip: bool = field(default=True)
     """ゲストアリ/ナシフラグ(サマリ集計用)"""
-    guest_skip2: bool
+    guest_skip2: bool = field(default=True)
     """ゲストアリ/ナシフラグ(詳細集計用)"""
-    ranked: int
+    ranked: int = field(default=3)
     """ランキング/レーティングで表示する順位"""
-    score_comparisons: bool
+    score_comparisons: bool = field(default=False)
     """スコア比較"""
-    statistics: bool
+    statistics: bool = field(default=False)
     """統計情報表示"""
-    stipulated: int
+    stipulated: int = field(default=0)
     """規定打数指定"""
-    stipulated_rate: float
+    stipulated_rate: float = field(default=0.05)
     """規定打数計算レート"""
-    unregistered_replace: bool
+    unregistered_replace: bool = field(default=True)
     """メンバー未登録プレイヤー名をゲストに置き換えるかフラグ
     - *True*: 置き換える
     - *False*: 置き換えない
     """
-    anonymous: bool
+    anonymous: bool = field(default=False)
     """匿名化フラグ"""
-    verbose: bool
+    verbose: bool = field(default=False)
     """詳細情報出力フラグ"""
-    versus_matrix: bool
+    versus_matrix: bool = field(default=False)
     """対戦マトリックス表示"""
-    collection: str
-    always_argument: list
+    collection: str = field(default="")
+    always_argument: list = field(default_factory=list)
     """オプションとして常に付与される文字列"""
-    target_mode: int
+    target_mode: int = field(default=0)
     """集計対象モードの指定
     - *0*: settingのデフォルトに従う
     - *not 0*: 指定値でmodeを上書き
     """
-    format: str
-    filename: str
-    interval: int
+    format: str = field(default="")
+    filename: str = field(default="")
+    interval: int = field(default=80)
 
     def default_reset(self):
         """デフォルト値にリセット"""
 
-        self.commandword = []
-        self.command_suffix = []
-        self.aggregation_range = str("当日")
-        self.individual = bool(True)
-        self.all_player = bool(False)
-        self.daily = bool(True)
-        self.fourfold = bool(True)
-        self.game_results = bool(False)
-        self.guest_skip = bool(True)
-        self.guest_skip2 = bool(True)
-        self.ranked = int(3)
-        self.score_comparisons = bool(False)
-        self.statistics = bool(False)
-        self.stipulated = int(0)
-        self.stipulated_rate = 0.05
-        self.unregistered_replace = bool(True)
-        self.anonymous = bool(False)
-        self.verbose = bool(False)
-        self.versus_matrix = bool(False)
-        self.collection = str("")
-        self.always_argument = []
-        self.target_mode = int(0)
-        self.format = str("")
-        self.filename = str("")
-        self.interval = 80
+        for f in fields(self):
+            if f.default is not MISSING:
+                setattr(self, f.name, f.default)
+            elif f.default_factory is not MISSING:
+                setattr(self, f.name, f.default_factory())
 
     def stipulated_calculation(self, game_count: int) -> int:
         """規定打数をゲーム数から計算

--- a/libs/domain/datamodels.py
+++ b/libs/domain/datamodels.py
@@ -91,9 +91,6 @@ class ChannelType(StrEnum):
 class CommandAttrs:
     """サブコマンド設定パラメータ"""
 
-    section: str
-    """サブコマンドセクション名"""
-
     commandword: list[str]
     """呼び出しキーワード"""
     command_suffix: list[str]

--- a/libs/domain/rule.py
+++ b/libs/domain/rule.py
@@ -294,7 +294,7 @@ class RuleSet:
         body_data: list = []
 
         if rule := self.data.get(rule_version):
-            body_data.append(["ルールバージョン", rule.rule_version])
+            body_data.append(["ルール識別子", rule.rule_version])
 
             # 集計モード
             match rule.mode:
@@ -307,7 +307,7 @@ class RuleSet:
 
             body_data.extend(
                 [
-                    ["点数", f"{rule.origin_point * 100}点持ち / {rule.return_point * 100}点返し"],
+                    ["素点", f"{rule.origin_point * 100}点持ち / {rule.return_point * 100}点返し"],
                     ["順位点", " / ".join([f"{pt}pt".replace("-", "▲") for pt in rule.rank_point])],
                     ["同点時", "順位点山分け" if rule.draw_split else "席順"],
                 ]
@@ -315,9 +315,9 @@ class RuleSet:
 
             # マッピング情報
             if keyword := [word for word, mapping_rule in self.keyword_mapping.items() if mapping_rule == rule_version]:
-                body_data.append(["成績登録キーワード", "、".join(keyword)])
+                body_data.append(["成績登録ワード", "、".join(keyword)])
             else:
-                body_data.append(["成績登録キーワード", "---"])
+                body_data.append(["成績登録ワード", "---"])
 
             # 記録時間
             body_data.append(["記録数", f"{rule.count} ゲーム"])

--- a/libs/domain/rule.py
+++ b/libs/domain/rule.py
@@ -47,6 +47,9 @@ class RuleData:
     undefined_word: int = 1
     """未定義ワードタイプ"""
 
+    remarks_words: list[str] = field(default_factory=list)
+    """メモ記録用ワード"""
+
     # ステータス
     first_time: ExtDt = field(default=ExtDt("1900-01-01 00:00:00"))
     """記録開始日時"""
@@ -417,10 +420,25 @@ class RuleSet:
 
     @property
     def rule_list(self) -> list[str]:
-        """定義済みルールセットの列挙
+        """定義済みルール識別子の列挙
 
         Returns:
             list[str]: ルール識別子
         """
 
         return [x.rule_version for x in self.data.values()]
+
+    @property
+    def remarks_words(self) -> list[str]:
+        """全ルールセットのメモ記録ワードを列挙
+
+        Returns:
+            list[str]: メモ記録ワード
+        """
+
+        ret: list[str] = []
+
+        for rule, data in self.data.items():
+            ret.extend(data.remarks_words)
+
+        return list(set(ret))

--- a/libs/functions/compose/text_item.py
+++ b/libs/functions/compose/text_item.py
@@ -55,9 +55,9 @@ def remarks(headword=False) -> str | list:
             case _:
                 remark_list.append("集計対象ルール すべて")
     elif len(g.params.get("rule_set", {})) > 1:
-        remark_list.append(f"集計対象ルール {'、'.join(map(str, g.params['rule_set'].values()))}")
+        remark_list.append(f"集計対象ルール {'、'.join(g.params['rule_set'].values())}")
     elif g.params.get("rule_version") != g.params.get("default_rule"):
-        remark_list.append(f"集計対象ルール {g.params['rule_version']}")
+        remark_list.append(f"集計対象ルール {'、'.join(g.params['rule_set'].values())}")
 
     if headword:
         if remark_list:

--- a/libs/utils/dictutil.py
+++ b/libs/utils/dictutil.py
@@ -44,9 +44,6 @@ def placeholder(subcom: "SubCommandLike", m: "MessageParserProtocol") -> "Placeh
     g.cfg.initialization()
     rule_version: str | None = None
 
-    # 設定周りのパラメータの取り込み
-    g.cfg.read_channel_config(m.status.source)
-
     # メンバー情報更新
     g.cfg.member.guest_name = lookup.get_guest()
     g.cfg.member.info = g.cfg.member.get_info
@@ -65,12 +62,16 @@ def placeholder(subcom: "SubCommandLike", m: "MessageParserProtocol") -> "Placeh
             **subcom.to_dict(),  # デフォルト値
         },
     )
-    default_rule = ret_dict.get("default_rule", g.cfg.mahjong.rule_version)
+
+    # チャンネル個別設定取り込み
+    g.cfg.read_channel_config(m.status.source, ret_dict)
+
     if "command_suffix" in ret_dict and isinstance(ret_dict["command_suffix"], list):
         for suffix in ret_dict.get("command_suffix", []):
             if rule_version := g.cfg.rule.keyword_mapping.get(m.keyword.removesuffix(suffix)):
-                ret_dict.update({"default_rule": rule_version})
-    rule_version = rule_version if rule_version else default_rule
+                break
+    rule_version = rule_version if rule_version else ret_dict.get("default_rule", g.cfg.mahjong.rule_version)
+
     ret_dict.update(
         {
             "rule_version": rule_version,
@@ -122,8 +123,8 @@ def placeholder(subcom: "SubCommandLike", m: "MessageParserProtocol") -> "Placeh
         for rule in g.cfg.rule.rule_list:  # 全ルール追加
             if g.cfg.rule.get_mode(rule) == ret_dict.get("target_mode"):
                 rule_list.append(rule)
-    else:
-        rule_list.append(ret_dict["default_rule"])
+    if not rule_list:
+        rule_list.append(rule_version)
     ret_dict["rule_set"] = {f"rule_{idx}": rule for idx, rule in enumerate(list(set(rule_list)))}
 
     # プレイヤー名

--- a/libs/utils/dictutil.py
+++ b/libs/utils/dictutil.py
@@ -70,7 +70,7 @@ def placeholder(subcom: "SubCommandLike", m: "MessageParserProtocol") -> "Placeh
         for suffix in ret_dict.get("command_suffix", []):
             if rule_version := g.cfg.rule.keyword_mapping.get(m.keyword.removesuffix(suffix)):
                 break
-    rule_version = rule_version if rule_version else ret_dict.get("default_rule", g.cfg.mahjong.rule_version)
+    rule_version = rule_version if rule_version else ret_dict.get("default_rule", g.cfg.setting.default_rule)
 
     ret_dict.update(
         {

--- a/libs/utils/validator.py
+++ b/libs/utils/validator.py
@@ -42,7 +42,7 @@ def check_namepattern(name: str, kind: Literal["member", "team"]) -> tuple[bool,
     ret_flg: bool = True
     ret_msg: str = "OK"
 
-    # 名前チェック
+    # 同名チェック
     check_list = _pattern_gen(g.cfg.member.all_lists)  # メンバーチェック
     if ret_flg and any(x in check_list for x in check_pattern):
         ret_flg, ret_msg = False, f"「{name}」は存在するメンバーです。"
@@ -68,7 +68,8 @@ def check_namepattern(name: str, kind: Literal["member", "team"]) -> tuple[bool,
     if ret_flg and CommandParser().is_valid_command(name):
         ret_flg, ret_msg = False, "オプションに使用される単語では登録できません。"
 
-    if ret_flg and name in set(list(g.keyword_dispatcher) + list(g.command_dispatcher) + g.cfg.word_list()):
+    # コマンドチェック
+    if ret_flg and name in g.cfg.word_list(list(g.keyword_dispatcher) + list(g.command_dispatcher)):
         ret_flg, ret_msg = False, "コマンドに使用される単語では登録できません。"
 
     return (ret_flg, ret_msg)

--- a/tests/config/param_data.py
+++ b/tests/config/param_data.py
@@ -21,6 +21,6 @@ keyword_test: dict[str, tuple[Any, ...]] = {
 # ヘルプキーワード
 help_word: dict[str, tuple[Any, ...]] = {
     # config, word
-    "help_default": ("empty.ini", "麻雀成績ヘルプ"),
+    "help_default": ("empty.ini", "麻雀ヘルプ"),
     "help_override": ("commandword.ini", "ヘルプの別名"),
 }

--- a/tests/config/test_keyword.py
+++ b/tests/config/test_keyword.py
@@ -39,4 +39,4 @@ def test_help(config, word, monkeypatch):
     monkeypatch.setattr(sys, "argv", ["progname", f"--config=tests/testdata/{config}"])
     configuration.setup(init_db=False)
 
-    assert g.cfg.setting.help == word
+    assert word in g.cfg.help.commandword

--- a/tests/testdata/commandword.ini
+++ b/tests/testdata/commandword.ini
@@ -1,8 +1,3 @@
-[mahjong]
-
-[setting]
-help = ヘルプの別名
-
 [results]
 commandword = 麻雀成績の別名１,麻雀成績の別名２
 
@@ -14,6 +9,9 @@ commandword = 麻雀ランキングの別名
 
 [report]
 commandword = 麻雀レポートの別名
+
+[help]
+commandword = ヘルプの別名
 
 [alias]
 results = 麻雀成績のエイリアス


### PR DESCRIPTION
This pull request introduces several improvements and refactors across the configuration, command handling, and help message systems. The main focus is on enhancing support for remarks keywords and suffixes, updating rule handling, and improving the clarity and flexibility of help messages. The changes also include refactoring to streamline configuration loading and keyword management.

**Enhancements to remarks keyword handling and configuration:**

* Added `remarks_suffix` to `SettingSection`, allowing multiple memo keywords and suffixes to be registered and used for memo recording. [[1]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cR212-R213) [[2]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cL246-R250)
* Updated the setup process in `configuration.py` to register remarks keywords and their suffixes per rule version, improving memo keyword flexibility and ensuring proper registration.

**Refactoring and improvements to configuration and commandword management:**

* Refactored `AppConfig.word_list` to dynamically collect commandwords and suffixes via `CommandType`, and to accept additional words for greater extensibility.
* Updated `AppConfig.overwrite` and `read_channel_config` to use `remarks_word` instead of `help` for protected values, and to accept a `PlaceholderDict` for parameter updates. [[1]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212L240-R252) [[2]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212L262-R277) [[3]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212R289-R290)

**Improvements to help message and keyword presentation:**

* Modified help messages to use "呼び出しワード" (call word) instead of "呼び出しキーワード" (keyword), and to display all registered memo keywords and suffixes. Help message sections now use updated terminology and improved rule version handling. [[1]](diffhunk://#diff-50f3210c9b6448a619d76ec07b7b40c0cb71eb9866414548f005c8c0b0c62dc9L59-R81) [[2]](diffhunk://#diff-50f3210c9b6448a619d76ec07b7b40c0cb71eb9866414548f005c8c0b0c62dc9L90-R126) [[3]](diffhunk://#diff-50f3210c9b6448a619d76ec07b7b40c0cb71eb9866414548f005c8c0b0c62dc9L136-R148)

**Rule handling and summary adjustments:**

* Updated result summary aggregation to respect rule-specific flying ignore settings, using the current rule version from parameters. [[1]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eR33-R37) [[2]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eL49-R55) [[3]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eL89-R95)
* Changed loader to use `setting.default_rule` for mode determination, improving rule version consistency.

**Miscellaneous and cleanup:**

* Refactored and cleaned up section and commandword configuration, removing unused attributes and improving initialization. [[1]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212R21-L35) [[2]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212L84-R90) [[3]](diffhunk://#diff-0e3cabd708a159e090882ad6df087ebb438a78faf65d803150bd5d2b7a395029L86-R86) [[4]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cL307) [[5]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cL369-L370) [[6]](diffhunk://#diff-1b7508f2d219b2d1cd19bbeca40fbd19107c9e66c6b248c18b4f75e8568f3915L6-R6)
* Adjusted dispatcher logic to use the new remarks keywords for memo recording, improving keyword matching.
* Improved regulation list formatting for help messages.
* Updated dispatcher channel config handling to use new method signature.

These changes collectively make the system more flexible and maintainable, especially around memo keyword handling and rule-specific configuration.