### PR TITLE
Pass parameters to loader.read_data in statistics_plot and game_summa…

### DIFF
--- a/libs/commands/graph/personal.py
+++ b/libs/commands/graph/personal.py
@@ -137,7 +137,7 @@ def statistics_plot(m: "MessageParserProtocol") -> None:
     # データ収集
     game_info = GameInfo()
     g.params.update({"guest_skip": g.params["guest_skip2"]})
-    df = loader.read_data("SUMMARY_DETAILS")
+    df = loader.read_data("SUMMARY_DETAILS", g.params)
 
     if df.empty:
         m.set_headline(message.random_reply(m, "no_hits"), StyleOptions())

--- a/libs/data/aggregate.py
+++ b/libs/data/aggregate.py
@@ -28,7 +28,7 @@ def game_summary(
 
     """
     # データ収集
-    df = loader.read_data("SUMMARY_TOTAL")
+    df = loader.read_data("SUMMARY_TOTAL", g.params)
 
     # 順位分布選択
     match g.params.get("mode", 4):

--- a/libs/data/loader.py
+++ b/libs/data/loader.py
@@ -34,7 +34,7 @@ def execute(sql: str, params: Optional[PlaceholderDict] = None) -> list[dict[str
 
     """
     if not params:
-        params = PlaceholderDict()
+        params = g.params
 
     ret: list[dict[str, Any]] = []
     sql = dbutil.query_modification(sql)
@@ -84,7 +84,7 @@ def read_data(keyword: str, params: Optional[PlaceholderDict] = None) -> pd.Data
 
     """
     if not params:
-        params = PlaceholderDict()
+        params = g.params
 
     params_dict: dict[str, Any] = {
         **params,


### PR DESCRIPTION
This pull request updates how parameters are handled when loading and processing data throughout the codebase. The main change is to use the global `g.params` object as the default parameter source, ensuring consistency and simplifying parameter management.

Parameter handling improvements:

* In `libs/data/loader.py`, the `execute` and `read_data` functions now default to using `g.params` instead of creating a new `PlaceholderDict` when no parameters are provided. [[1]](diffhunk://#diff-652389db3d37621f703381a6ef6510402c1eec1eefc0f1a0ebeb61f420ea99b0L37-R37) [[2]](diffhunk://#diff-652389db3d37621f703381a6ef6510402c1eec1eefc0f1a0ebeb61f420ea99b0L87-R87)
* In `libs/commands/graph/personal.py`, the `statistics_plot` function passes `g.params` to `loader.read_data` for improved data loading consistency.
* In `libs/data/aggregate.py`, the `game_summary` function passes `g.params` to `loader.read_data` for summary data retrieval.…ry for improved data handling