### PR TITLE
Develop

### DIFF
--- a/integrations/discord/events/audioop.py
+++ b/integrations/discord/events/audioop.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 """
 integrations/discord/events/audioop.py
 

--- a/integrations/factory.py
+++ b/integrations/factory.py
@@ -2,7 +2,7 @@
 integrations/factory.py
 """
 
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Literal, TypeAlias, Union, overload
 
 from integrations.discord.adapter import ServiceAdapter as discord_adapter
 from integrations.slack.adapter import ServiceAdapter as slack_adapter
@@ -10,8 +10,15 @@ from integrations.standard_io.adapter import ServiceAdapter as std_adapter
 from integrations.web.adapter import ServiceAdapter as web_adapter
 
 if TYPE_CHECKING:
-    from integrations.base.interface import AdapterInterface
     from libs.bootstrap.app_config import AppConfig
+
+AdapterType: TypeAlias = Union[
+    slack_adapter,
+    discord_adapter,
+    web_adapter,
+    std_adapter,
+]
+"""アダプタインターフェース"""
 
 
 @overload
@@ -30,7 +37,7 @@ def select_adapter(selected_service: Literal["web"], conf: "AppConfig") -> web_a
 def select_adapter(selected_service: Literal["standard_io"], conf: "AppConfig") -> std_adapter: ...
 
 
-def select_adapter(selected_service: str, conf: "AppConfig") -> "AdapterInterface":
+def select_adapter(selected_service: str, conf: "AppConfig") -> AdapterType:
     """
     インターフェース選択
 


### PR DESCRIPTION
This pull request introduces type hinting improvements and minor configuration changes to the adapter factory and Discord integration. The main focus is on enhancing type safety and clarity for adapter selection, along with a small configuration update for mypy.

Type hinting and type alias improvements:

* Added a new `AdapterType` type alias using `TypeAlias` and `Union` to represent all possible adapter types in `integrations/factory.py`, and updated the return type of `select_adapter` accordingly. [[1]](diffhunk://#diff-a8d3389f8d5bf42a5293be9697fe2cc27cf858d988f3926604e7d54dbb77e596L5-R22) [[2]](diffhunk://#diff-a8d3389f8d5bf42a5293be9697fe2cc27cf858d988f3926604e7d54dbb77e596L33-R40)

Configuration and compatibility:

* Added a `# mypy: ignore-errors` directive at the top of `integrations/discord/events/audioop.py` to suppress mypy type checking errors in that file.