### PR TITLE
Develop

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, cast
 
 import libs.global_value as g
 from libs.bootstrap import configuration
+from libs.types import ServiceType
 
 if TYPE_CHECKING:
     from integrations.discord.adapter import ServiceAdapter as discord_adapter
@@ -42,19 +43,19 @@ if __name__ == "__main__":
     configuration.setup()
 
     match g.cfg.selected_service:
-        case "slack":
+        case ServiceType.SLACK:
             import integrations.slack.events.handler as slack
 
             slack.main(cast("slack_adapter", g.adapter))
-        case "discord":
+        case ServiceType.DISCORD:
             import integrations.discord.events.handler as discord
 
             discord.main(cast("discord_adapter", g.adapter))
-        case "standard_io":
+        case ServiceType.STANDARD_IO:
             import integrations.standard_io.events.handler as standard_io
 
             standard_io.main(cast("std_adapter", g.adapter))
-        case "web":
+        case ServiceType.WEB:
             import integrations.web.events.handler as webapp
 
             webapp.main(cast("web_adapter", g.adapter))

--- a/integrations/discord/adapter.py
+++ b/integrations/discord/adapter.py
@@ -9,6 +9,7 @@ from integrations.discord.api import AdapterAPI
 from integrations.discord.config import SvcConfig
 from integrations.discord.functions import SvcFunctions
 from integrations.discord.parser import MessageParser
+from libs.types import ServiceType
 
 if TYPE_CHECKING:
     from configparser import ConfigParser
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
 class ServiceAdapter(AdapterInterface[SvcConfig, AdapterAPI, SvcFunctions, MessageParser]):
     """discord interface"""
 
-    interface_type = "discord"
+    interface_type = ServiceType.DISCORD
 
     def __init__(self, parser: "ConfigParser"):
         self.conf = SvcConfig(main_conf=parser)

--- a/integrations/discord/api.py
+++ b/integrations/discord/api.py
@@ -13,8 +13,7 @@ from table2ascii import PresetStyle, table2ascii
 
 import integrations.discord.events.audioop as _audioop
 from integrations.base.interface import APIInterface
-from libs.domain.datamodels import CommandType
-from libs.types import StyleOptions
+from libs.types import CommandType, StyleOptions
 from libs.utils import converter, formatter, textutil
 from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/integrations/discord/events/comparison.py
+++ b/integrations/discord/events/comparison.py
@@ -12,9 +12,9 @@ from discord.channel import TextChannel
 
 import libs.global_value as g
 from libs.data import modify, search
-from libs.domain.datamodels import CommandType, ComparisonResults
+from libs.domain.datamodels import ComparisonResults
 from libs.domain.score import GameResult
-from libs.types import ActionStatus, RemarkDict, StyleOptions
+from libs.types import ActionStatus, CommandType, RemarkDict, StyleOptions
 from libs.utils import formatter, validator
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 from libs.utils.timekit import Format

--- a/integrations/discord/events/comparison.py
+++ b/integrations/discord/events/comparison.py
@@ -12,9 +12,9 @@ from discord.channel import TextChannel
 
 import libs.global_value as g
 from libs.data import modify, search
-from libs.domain.datamodels import ActionStatus, CommandType, ComparisonResults
+from libs.domain.datamodels import CommandType, ComparisonResults
 from libs.domain.score import GameResult
-from libs.types import RemarkDict, StyleOptions
+from libs.types import ActionStatus, RemarkDict, StyleOptions
 from libs.utils import formatter, validator
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 from libs.utils.timekit import Format

--- a/integrations/discord/events/handler.py
+++ b/integrations/discord/events/handler.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 import integrations.discord.events.audioop as _audioop
 import libs.dispatcher
-from libs.domain.datamodels import MessageStatus
+from libs.types import MessageStatus
 
 if TYPE_CHECKING:
     from integrations.discord.adapter import ServiceAdapter

--- a/integrations/discord/functions.py
+++ b/integrations/discord/functions.py
@@ -8,7 +8,7 @@ from discord import Forbidden, NotFound
 from discord.channel import TextChannel
 
 from integrations.base.interface import FunctionsInterface
-from libs.domain.datamodels import ActionStatus
+from libs.types import ActionStatus
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 
 if TYPE_CHECKING:

--- a/integrations/discord/parser.py
+++ b/integrations/discord/parser.py
@@ -10,7 +10,7 @@ from discord.channel import TextChannel
 import libs.global_value as g
 from integrations.base.interface import MessageParserDataMixin, MessageParserInterface
 from integrations.protocols import MsgData, PostData, StatusData
-from libs.domain.datamodels import CommandType
+from libs.types import CommandType
 
 if TYPE_CHECKING:
     from integrations.discord.adapter import ServiceAdapter

--- a/integrations/factory.py
+++ b/integrations/factory.py
@@ -2,15 +2,17 @@
 integrations/factory.py
 """
 
-from typing import TYPE_CHECKING, Literal, TypeAlias, Union, overload
+from typing import TYPE_CHECKING, Literal, NoReturn, TypeAlias, Union, overload
 
 from integrations.discord.adapter import ServiceAdapter as discord_adapter
 from integrations.slack.adapter import ServiceAdapter as slack_adapter
 from integrations.standard_io.adapter import ServiceAdapter as std_adapter
 from integrations.web.adapter import ServiceAdapter as web_adapter
+from libs.types import ServiceType
 
 if TYPE_CHECKING:
     from libs.bootstrap.app_config import AppConfig
+
 
 AdapterType: TypeAlias = Union[
     slack_adapter,
@@ -22,27 +24,35 @@ AdapterType: TypeAlias = Union[
 
 
 @overload
-def select_adapter(selected_service: Literal["slack"], conf: "AppConfig") -> slack_adapter: ...
+def select_adapter(selected_service: Literal[ServiceType.SLACK], conf: "AppConfig") -> slack_adapter: ...
 
 
 @overload
-def select_adapter(selected_service: Literal["discord"], conf: "AppConfig") -> discord_adapter: ...
+def select_adapter(selected_service: Literal[ServiceType.DISCORD], conf: "AppConfig") -> discord_adapter: ...
 
 
 @overload
-def select_adapter(selected_service: Literal["web"], conf: "AppConfig") -> web_adapter: ...
+def select_adapter(selected_service: Literal[ServiceType.WEB], conf: "AppConfig") -> web_adapter: ...
 
 
 @overload
-def select_adapter(selected_service: Literal["standard_io"], conf: "AppConfig") -> std_adapter: ...
+def select_adapter(selected_service: Literal[ServiceType.STANDARD_IO], conf: "AppConfig") -> std_adapter: ...
 
 
-def select_adapter(selected_service: str, conf: "AppConfig") -> AdapterType:
+@overload
+def select_adapter(selected_service: Literal[ServiceType.UNKNOWN], conf: "AppConfig") -> NoReturn: ...
+
+
+@overload
+def select_adapter(selected_service: ServiceType, conf: "AppConfig") -> AdapterType: ...
+
+
+def select_adapter(selected_service: ServiceType, conf: "AppConfig") -> AdapterType:
     """
     インターフェース選択
 
     Args:
-        selected_service (str): 選択サービス
+        selected_service (ServiceType): 選択サービス
         conf (AppConfig): 設定ファイル
 
     Raises:
@@ -53,13 +63,13 @@ def select_adapter(selected_service: str, conf: "AppConfig") -> AdapterType:
 
     """
     match selected_service:
-        case "slack":
+        case ServiceType.SLACK:
             return slack_adapter(conf.main_parser)
-        case "discord":
+        case ServiceType.DISCORD:
             return discord_adapter(conf.main_parser)
-        case "web":
+        case ServiceType.WEB:
             return web_adapter(conf.main_parser)
-        case "standard_io":
+        case ServiceType.STANDARD_IO:
             return std_adapter(conf.main_parser)
         case _:
             raise ValueError(f"Unknown service: {selected_service}")

--- a/integrations/protocols.py
+++ b/integrations/protocols.py
@@ -5,8 +5,8 @@ integrations/protocols.py
 from dataclasses import dataclass, field, fields, is_dataclass
 from typing import TYPE_CHECKING, Any, Optional, Protocol
 
-from libs.domain.datamodels import ActionStatus, ChannelType, CommandType
-from libs.types import MessageStatus
+from libs.domain.datamodels import ChannelType, CommandType
+from libs.types import ActionStatus, MessageStatus
 
 if TYPE_CHECKING:
     from pathlib import Path  # noqa: F401

--- a/integrations/protocols.py
+++ b/integrations/protocols.py
@@ -5,8 +5,8 @@ integrations/protocols.py
 from dataclasses import dataclass, field, fields, is_dataclass
 from typing import TYPE_CHECKING, Any, Optional, Protocol
 
-from libs.domain.datamodels import ChannelType, CommandType
-from libs.types import ActionStatus, MessageStatus
+from libs.domain.datamodels import CommandType
+from libs.types import ActionStatus, ChannelType, MessageStatus
 
 if TYPE_CHECKING:
     from pathlib import Path  # noqa: F401

--- a/integrations/protocols.py
+++ b/integrations/protocols.py
@@ -5,8 +5,7 @@ integrations/protocols.py
 from dataclasses import dataclass, field, fields, is_dataclass
 from typing import TYPE_CHECKING, Any, Optional, Protocol
 
-from libs.domain.datamodels import CommandType
-from libs.types import ActionStatus, ChannelType, MessageStatus
+from libs.types import ActionStatus, ChannelType, CommandType, MessageStatus
 
 if TYPE_CHECKING:
     from pathlib import Path  # noqa: F401

--- a/integrations/protocols.py
+++ b/integrations/protocols.py
@@ -5,7 +5,8 @@ integrations/protocols.py
 from dataclasses import dataclass, field, fields, is_dataclass
 from typing import TYPE_CHECKING, Any, Optional, Protocol
 
-from libs.domain.datamodels import ActionStatus, ChannelType, CommandType, MessageStatus
+from libs.domain.datamodels import ActionStatus, ChannelType, CommandType
+from libs.types import MessageStatus
 
 if TYPE_CHECKING:
     from pathlib import Path  # noqa: F401

--- a/integrations/slack/adapter.py
+++ b/integrations/slack/adapter.py
@@ -9,6 +9,7 @@ from integrations.slack.api import AdapterAPI
 from integrations.slack.config import SvcConfig
 from integrations.slack.functions import SvcFunctions
 from integrations.slack.parser import MessageParser
+from libs.types import ServiceType
 
 if TYPE_CHECKING:
     from configparser import ConfigParser
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
 class ServiceAdapter(AdapterInterface[SvcConfig, AdapterAPI, SvcFunctions, MessageParser]):
     """slack interface"""
 
-    interface_type = "slack"
+    interface_type = ServiceType.SLACK
 
     def __init__(self, parser: "ConfigParser"):
         self.conf = SvcConfig(main_conf=parser)

--- a/integrations/slack/events/comparison.py
+++ b/integrations/slack/events/comparison.py
@@ -7,9 +7,9 @@ from typing import TYPE_CHECKING, cast
 
 import libs.global_value as g
 from libs.data import lookup, modify, search
-from libs.domain.datamodels import ActionStatus, CommandType, ComparisonResults
+from libs.domain.datamodels import CommandType, ComparisonResults
 from libs.domain.score import GameResult
-from libs.types import StyleOptions
+from libs.types import ActionStatus, StyleOptions
 from libs.utils import formatter, validator
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 from libs.utils.timekit import Format

--- a/integrations/slack/events/comparison.py
+++ b/integrations/slack/events/comparison.py
@@ -7,9 +7,9 @@ from typing import TYPE_CHECKING, cast
 
 import libs.global_value as g
 from libs.data import lookup, modify, search
-from libs.domain.datamodels import CommandType, ComparisonResults
+from libs.domain.datamodels import ComparisonResults
 from libs.domain.score import GameResult
-from libs.types import ActionStatus, StyleOptions
+from libs.types import ActionStatus, CommandType, StyleOptions
 from libs.utils import formatter, validator
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 from libs.utils.timekit import Format

--- a/integrations/slack/events/home_tab/personal.py
+++ b/integrations/slack/events/home_tab/personal.py
@@ -10,7 +10,7 @@ from integrations.slack.adapter import ServiceAdapter
 from integrations.slack.events.handler_registry import register
 from integrations.slack.events.home_tab import ui_parts
 from libs.commands.results import detail
-from libs.domain.datamodels import CommandType
+from libs.types import CommandType
 from libs.utils import dictutil
 from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/integrations/slack/events/home_tab/ranking.py
+++ b/integrations/slack/events/home_tab/ranking.py
@@ -10,7 +10,7 @@ from integrations.slack.adapter import ServiceAdapter
 from integrations.slack.events.handler_registry import register
 from integrations.slack.events.home_tab import ui_parts
 from libs.commands.ranking import ranking
-from libs.domain.datamodels import CommandType
+from libs.types import CommandType
 from libs.utils import dictutil
 from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/integrations/slack/events/home_tab/summary.py
+++ b/integrations/slack/events/home_tab/summary.py
@@ -12,7 +12,7 @@ from integrations.slack.events.home_tab import ui_parts
 from libs.commands.graph import summary as graph_summary
 from libs.commands.ranking import rating
 from libs.commands.results import summary as results_summary
-from libs.domain.datamodels import CommandType
+from libs.types import CommandType
 from libs.utils import dictutil
 from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/integrations/slack/events/home_tab/versus.py
+++ b/integrations/slack/events/home_tab/versus.py
@@ -10,7 +10,7 @@ from integrations.slack.adapter import ServiceAdapter
 from integrations.slack.events.handler_registry import register
 from integrations.slack.events.home_tab import ui_parts
 from libs.commands.results import versus
-from libs.domain.datamodels import CommandType
+from libs.types import CommandType
 from libs.utils import dictutil
 from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/integrations/slack/functions.py
+++ b/integrations/slack/functions.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 import libs.global_value as g
 from integrations.base.interface import FunctionsInterface
 from libs.data import lookup
-from libs.domain.datamodels import ActionStatus
+from libs.types import ActionStatus
 from libs.utils import validator
 from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/integrations/slack/parser.py
+++ b/integrations/slack/parser.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING, Any, cast
 import libs.global_value as g
 from integrations.base.interface import MessageParserDataMixin, MessageParserInterface
 from integrations.protocols import MsgData, PostData, StatusData
-from libs.domain.datamodels import ChannelType, CommandType
-from libs.types import MessageStatus
+from libs.domain.datamodels import CommandType
+from libs.types import ChannelType, MessageStatus
 
 if TYPE_CHECKING:
     from integrations.slack.adapter import ServiceAdapter

--- a/integrations/slack/parser.py
+++ b/integrations/slack/parser.py
@@ -8,7 +8,8 @@ from typing import TYPE_CHECKING, Any, cast
 import libs.global_value as g
 from integrations.base.interface import MessageParserDataMixin, MessageParserInterface
 from integrations.protocols import MsgData, PostData, StatusData
-from libs.domain.datamodels import ChannelType, CommandType, MessageStatus
+from libs.domain.datamodels import ChannelType, CommandType
+from libs.types import MessageStatus
 
 if TYPE_CHECKING:
     from integrations.slack.adapter import ServiceAdapter

--- a/integrations/slack/parser.py
+++ b/integrations/slack/parser.py
@@ -8,8 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 import libs.global_value as g
 from integrations.base.interface import MessageParserDataMixin, MessageParserInterface
 from integrations.protocols import MsgData, PostData, StatusData
-from libs.domain.datamodels import CommandType
-from libs.types import ChannelType, MessageStatus
+from libs.types import ChannelType, CommandType, MessageStatus
 
 if TYPE_CHECKING:
     from integrations.slack.adapter import ServiceAdapter

--- a/integrations/standard_io/adapter.py
+++ b/integrations/standard_io/adapter.py
@@ -9,6 +9,7 @@ from integrations.standard_io.api import AdapterAPI
 from integrations.standard_io.config import SvcConfig
 from integrations.standard_io.functions import SvcFunctions
 from integrations.standard_io.parser import MessageParser
+from libs.types import ServiceType
 
 if TYPE_CHECKING:
     from configparser import ConfigParser
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
 class ServiceAdapter(AdapterInterface[SvcConfig, AdapterAPI, SvcFunctions, MessageParser]):
     """standard input/output interface"""
 
-    interface_type = "standard_io"
+    interface_type = ServiceType.STANDARD_IO
 
     def __init__(self, parser: "ConfigParser"):
         self.conf = SvcConfig(main_conf=parser)

--- a/integrations/standard_io/parser.py
+++ b/integrations/standard_io/parser.py
@@ -7,8 +7,7 @@ from typing import Any, cast
 
 from integrations.base.interface import MessageParserDataMixin, MessageParserInterface
 from integrations.protocols import MsgData, PostData, StatusData
-from libs.domain.datamodels import ChannelType
-from libs.types import MessageStatus
+from libs.types import ChannelType, MessageStatus
 
 
 class MessageParser(MessageParserDataMixin, MessageParserInterface):

--- a/integrations/standard_io/parser.py
+++ b/integrations/standard_io/parser.py
@@ -7,7 +7,8 @@ from typing import Any, cast
 
 from integrations.base.interface import MessageParserDataMixin, MessageParserInterface
 from integrations.protocols import MsgData, PostData, StatusData
-from libs.domain.datamodels import ChannelType, MessageStatus
+from libs.domain.datamodels import ChannelType
+from libs.types import MessageStatus
 
 
 class MessageParser(MessageParserDataMixin, MessageParserInterface):

--- a/integrations/web/adapter.py
+++ b/integrations/web/adapter.py
@@ -9,6 +9,7 @@ from integrations.web.api import AdapterAPI
 from integrations.web.config import SvcConfig
 from integrations.web.functions import SvcFunctions
 from integrations.web.parser import MessageParser
+from libs.types import ServiceType
 
 if TYPE_CHECKING:
     from configparser import ConfigParser
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
 class ServiceAdapter(AdapterInterface[SvcConfig, AdapterAPI, SvcFunctions, MessageParser]):
     """web interface"""
 
-    interface_type = "web"
+    interface_type = ServiceType.WEB
 
     def __init__(self, parser: "ConfigParser"):
         self.conf = SvcConfig(main_conf=parser)

--- a/integrations/web/parser.py
+++ b/integrations/web/parser.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from integrations.base.interface import MessageParserDataMixin, MessageParserInterface
 from integrations.protocols import MsgData, PostData, StatusData
-from libs.domain.datamodels import MessageStatus
+from libs.types import MessageStatus
 
 
 class MessageParser(MessageParserDataMixin, MessageParserInterface):

--- a/libs/bootstrap/app_config.py
+++ b/libs/bootstrap/app_config.py
@@ -18,9 +18,8 @@ from libs.commands.registry.team import TeamSection
 from libs.commands.report.entry import ReportConfig
 from libs.commands.results.entry import ResultsConfig
 from libs.data.lookup import read_memberslist
-from libs.domain.datamodels import CommandType
 from libs.domain.rule import RuleSet
-from libs.types import GradeTableDict, ServiceType
+from libs.types import CommandType, GradeTableDict, ServiceType
 
 if TYPE_CHECKING:
     from libs.bootstrap.section import SubCommands

--- a/libs/bootstrap/app_config.py
+++ b/libs/bootstrap/app_config.py
@@ -20,7 +20,7 @@ from libs.commands.results.entry import ResultsConfig
 from libs.data.lookup import read_memberslist
 from libs.domain.datamodels import CommandType
 from libs.domain.rule import RuleSet
-from libs.types import GradeTableDict
+from libs.types import GradeTableDict, ServiceType
 
 if TYPE_CHECKING:
     from libs.bootstrap.section import SubCommands
@@ -125,7 +125,7 @@ class AppConfig:
         """スクリプトが保存されているディレクトリパス"""
         self.config_dir: Path = self.config_file.absolute().parent
         """設定ファイルが保存されているディレクトリパス"""
-        self.selected_service: Literal["slack", "discord", "web", "standard_io"] = "slack"
+        self.selected_service: ServiceType = ServiceType.SLACK
         """連携先サービス"""
 
         # 設定値

--- a/libs/bootstrap/configuration.py
+++ b/libs/bootstrap/configuration.py
@@ -22,7 +22,7 @@ from libs.bootstrap.app_config import AppConfig
 from libs.commands.registry import member, team
 from libs.data import initialization, lookup
 from libs.functions.compose import text_item
-from libs.types import Args, StyleOptions
+from libs.types import Args, ServiceType, StyleOptions
 
 if TYPE_CHECKING:
     from integrations.protocols import MessageParserProtocol
@@ -240,20 +240,20 @@ def setup(init_db: bool = True) -> None:
     # 連携サービス
     match g.args.service:
         case "slack":
-            g.cfg.selected_service = "slack"
+            g.cfg.selected_service = ServiceType.SLACK
         case "discord":
-            g.cfg.selected_service = "discord"
+            g.cfg.selected_service = ServiceType.DISCORD
         case "standard_io" | "std":
-            g.cfg.selected_service = "standard_io"
+            g.cfg.selected_service = ServiceType.STANDARD_IO
         case "web" | "flask":
-            g.cfg.selected_service = "web"
+            g.cfg.selected_service = ServiceType.WEB
         case _:
             sys.exit()
 
     if not hasattr(g.args, "testcase"):
         g.args.testcase = None
     else:
-        g.cfg.selected_service = "standard_io"
+        g.cfg.selected_service = ServiceType.STANDARD_IO
 
     g.adapter = factory.select_adapter(g.cfg.selected_service, g.cfg)
 

--- a/libs/bootstrap/configuration.py
+++ b/libs/bootstrap/configuration.py
@@ -21,8 +21,9 @@ from integrations import factory
 from libs.bootstrap.app_config import AppConfig
 from libs.commands.registry import member, team
 from libs.data import initialization, lookup
+from libs.domain.datamodels import Args
 from libs.functions.compose import text_item
-from libs.types import Args, ServiceType, StyleOptions
+from libs.types import ServiceType, StyleOptions
 
 if TYPE_CHECKING:
     from integrations.protocols import MessageParserProtocol

--- a/libs/commands/graph/entry.py
+++ b/libs/commands/graph/entry.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import libs.global_value as g
 from libs.bootstrap.section import SubCommands
 from libs.commands.graph import personal, rating, summary
-from libs.domain.datamodels import CommandType
+from libs.types import CommandType
 from libs.utils import dictutil
 
 if TYPE_CHECKING:

--- a/libs/commands/help/entry.py
+++ b/libs/commands/help/entry.py
@@ -8,8 +8,7 @@ from typing import TYPE_CHECKING
 import libs.global_value as g
 from libs.bootstrap.section import SubCommands
 from libs.data import lookup
-from libs.domain.datamodels import CommandType
-from libs.types import StyleOptions
+from libs.types import CommandType, StyleOptions
 from libs.utils import dictutil
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 

--- a/libs/commands/ranking/entry.py
+++ b/libs/commands/ranking/entry.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import libs.global_value as g
 from libs.bootstrap.section import SubCommands
 from libs.commands.ranking import ranking, rating
-from libs.domain.datamodels import CommandType
+from libs.types import CommandType
 from libs.utils import dictutil
 
 if TYPE_CHECKING:

--- a/libs/commands/ranking/rating.py
+++ b/libs/commands/ranking/rating.py
@@ -8,10 +8,10 @@ import pandas as pd
 
 import libs.global_value as g
 from libs.data import aggregate, loader
-from libs.domain.datamodels import CommandType, GameInfo
+from libs.domain.datamodels import GameInfo
 from libs.functions import message
 from libs.functions.compose import badge
-from libs.types import StyleOptions
+from libs.types import CommandType, StyleOptions
 from libs.utils import converter, formatter
 
 if TYPE_CHECKING:

--- a/libs/commands/registry/member.py
+++ b/libs/commands/registry/member.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, TypedDict, cast
 import libs.global_value as g
 from libs.bootstrap.section import BaseSection
 from libs.data import loader, modify
-from libs.domain.datamodels import CommandType
+from libs.types import CommandType
 from libs.utils import dbutil, textutil, validator
 
 if TYPE_CHECKING:

--- a/libs/commands/registry/team.py
+++ b/libs/commands/registry/team.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, TypedDict, cast
 import libs.global_value as g
 from libs.bootstrap.section import BaseSection
 from libs.data import initialization, loader, modify
-from libs.domain.datamodels import CommandType
+from libs.types import CommandType
 from libs.utils import dbutil, formatter, textutil, validator
 
 if TYPE_CHECKING:

--- a/libs/commands/report/entry.py
+++ b/libs/commands/report/entry.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import libs.global_value as g
 from libs.bootstrap.section import SubCommands
 from libs.commands.report import matrix, monthly, stats_list, stats_report, winner
-from libs.domain.datamodels import CommandType
+from libs.types import CommandType
 from libs.utils import dictutil
 
 if TYPE_CHECKING:

--- a/libs/commands/results/entry.py
+++ b/libs/commands/results/entry.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import libs.global_value as g
 from libs.bootstrap.section import SubCommands
 from libs.commands.results import detail, summary, versus
-from libs.domain.datamodels import CommandType
+from libs.types import CommandType
 from libs.utils import dictutil
 
 if TYPE_CHECKING:

--- a/libs/data/lookup.py
+++ b/libs/data/lookup.py
@@ -10,8 +10,9 @@ from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import libs.global_value as g
 from libs.data import loader
-from libs.domain.datamodels import ChannelType, CommandType
+from libs.domain.datamodels import CommandType
 from libs.domain.score import GameResult
+from libs.types import ChannelType
 from libs.utils import dbutil
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 from libs.utils.timekit import Format

--- a/libs/data/lookup.py
+++ b/libs/data/lookup.py
@@ -10,9 +10,8 @@ from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import libs.global_value as g
 from libs.data import loader
-from libs.domain.datamodels import CommandType
 from libs.domain.score import GameResult
-from libs.types import ChannelType
+from libs.types import ChannelType, CommandType
 from libs.utils import dbutil
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 from libs.utils.timekit import Format

--- a/libs/data/modify.py
+++ b/libs/data/modify.py
@@ -12,9 +12,9 @@ from typing import TYPE_CHECKING, Any, cast
 
 import libs.global_value as g
 from libs.data import lookup
-from libs.domain.datamodels import ActionStatus, MessageStatus
+from libs.domain.datamodels import ActionStatus
 from libs.functions import message
-from libs.types import StyleOptions
+from libs.types import MessageStatus, StyleOptions
 from libs.utils import dbutil, formatter
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 from libs.utils.timekit import Format

--- a/libs/data/modify.py
+++ b/libs/data/modify.py
@@ -12,9 +12,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 import libs.global_value as g
 from libs.data import lookup
-from libs.domain.datamodels import ActionStatus
 from libs.functions import message
-from libs.types import MessageStatus, StyleOptions
+from libs.types import ActionStatus, MessageStatus, StyleOptions
 from libs.utils import dbutil, formatter
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 from libs.utils.timekit import Format

--- a/libs/dispatcher.py
+++ b/libs/dispatcher.py
@@ -9,10 +9,9 @@ from typing import TYPE_CHECKING
 import libs.global_value as g
 from integrations import factory
 from libs.data import lookup, modify
-from libs.domain.datamodels import MessageStatus
 from libs.domain.score import GameResult
 from libs.functions import message
-from libs.types import StyleOptions
+from libs.types import MessageStatus, StyleOptions
 from libs.utils import formatter, validator
 
 if TYPE_CHECKING:

--- a/libs/domain/datamodels.py
+++ b/libs/domain/datamodels.py
@@ -44,21 +44,6 @@ class CommandType(StrEnum):
     """未定義"""
 
 
-class MessageStatus(StrEnum):
-    """メッセージステータス"""
-
-    APPEND = "message_append"
-    """新規ポストイベント"""
-    CHANGED = "message_changed"
-    """編集イベント"""
-    DELETED = "message_deleted"
-    """削除イベント"""
-    DO_NOTHING = "do_nothing"
-    """何もしなくてよいイベント"""
-    UNDETERMINED = "undetermined"
-    """未定義状態"""
-
-
 class ActionStatus(StrEnum):
     """DBに対する操作"""
 

--- a/libs/domain/datamodels.py
+++ b/libs/domain/datamodels.py
@@ -44,17 +44,6 @@ class CommandType(StrEnum):
     """未定義"""
 
 
-class ActionStatus(StrEnum):
-    """DBに対する操作"""
-
-    CHANGE = "change"
-    """insert/updateが実行された"""
-    DELETE = "delete"
-    """deleteが実行された"""
-    NOTHING = "nothing"
-    """何もしてない"""
-
-
 class ChannelType(StrEnum):
     """チャンネルタイプ"""
 

--- a/libs/domain/datamodels.py
+++ b/libs/domain/datamodels.py
@@ -44,23 +44,6 @@ class CommandType(StrEnum):
     """未定義"""
 
 
-class ChannelType(StrEnum):
-    """チャンネルタイプ"""
-
-    CHANNEL = "normal"
-    """通常チャンネル"""
-    PRIVATE = "private"
-    """プライベートチャンネル"""
-    DIRECT_MESSAGE = "direct_message"
-    """ダイレクトメッセージ"""
-    HOME_APP = "home_app"
-    """Slackのホームアプリ"""
-    SEARCH = "search_api"
-    """検索API"""
-    UNDETERMINED = "undetermined"
-    """未定義状態"""
-
-
 @dataclass
 class GameInfo:
     """ゲーム集計情報"""

--- a/libs/domain/datamodels.py
+++ b/libs/domain/datamodels.py
@@ -13,9 +13,47 @@ from libs.utils.timekit import ExtendedDatetime as ExtDt
 from libs.utils.timekit import Format
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from integrations.protocols import MessageParserProtocol
     from libs.domain.score import GameResult
     from libs.types import RemarkDict
+
+
+@dataclass
+class Args:
+    """コマンドラインオプション"""
+
+    service: str
+    config: "Path"
+    """設定ファイルパス"""
+
+    debug: int
+    """デバッグ出力フラグ"""
+    verbose: int
+    """詳細出力フラグ"""
+
+    moderate: bool
+    """INFO以下のログレベル出力を抑止"""
+    notime: bool
+    """ログに日付を付与しない"""
+
+    # Only allowed when --service=standard_io
+    text: str
+
+    # Only allowed when --service=web
+    host: str
+    port: int
+
+    # dbtools
+    compar: bool
+    unification: "Path"
+    recalculation: bool
+    export_data: str
+    import_data: str
+    vacuum: bool
+    gen_test_data: int
+    testcase: Optional["Path"]
 
 
 @dataclass

--- a/libs/domain/datamodels.py
+++ b/libs/domain/datamodels.py
@@ -4,7 +4,6 @@ libs/domain/datamodels.py
 
 import logging
 from dataclasses import MISSING, dataclass, field, fields
-from enum import StrEnum
 from math import ceil
 from typing import TYPE_CHECKING, Literal, Optional
 
@@ -17,31 +16,6 @@ if TYPE_CHECKING:
     from integrations.protocols import MessageParserProtocol
     from libs.domain.score import GameResult
     from libs.types import RemarkDict
-
-
-class CommandType(StrEnum):
-    """実行(する/した)サブコマンド"""
-
-    RESULTS = "results"
-    """成績サマリ"""
-    GRAPH = "graph"
-    """グラフ生成"""
-    RANKING = "ranking"
-    """ランキング"""
-    RATING = "rating"
-    """レーティング"""
-    REPORT = "report"
-    """レポート"""
-    MEMBER_LIST = "member"
-    """メンバー一覧"""
-    TEAM_LIST = "team"
-    """チーム一覧"""
-    HELP = "help"
-    """ヘルプ"""
-    COMPARISON = "comparison"
-    """突合処理"""
-    UNKNOWN = "unknown"
-    """未定義"""
 
 
 @dataclass

--- a/libs/domain/placeholder.py
+++ b/libs/domain/placeholder.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 from libs.data import lookup
 from libs.domain.datamodels import ParameterData
+from libs.types import ServiceType
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 
 if TYPE_CHECKING:
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
 class PlaceholderBuilder(ParameterData):
     """プレースホルダ構築クラス"""
 
-    service_type: str = field(default="")
+    service_type: ServiceType = field(default=ServiceType.UNKNOWN)
     """連携先サービス"""
     command: str = field(default="")
     """コマンド名"""

--- a/libs/functions/message.py
+++ b/libs/functions/message.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import libs.global_value as g
-from libs.domain.datamodels import CommandType
 from libs.functions.compose import text_item
+from libs.types import CommandType
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 from libs.utils.timekit import Format
 

--- a/libs/functions/tools/comparison.py
+++ b/libs/functions/tools/comparison.py
@@ -9,6 +9,7 @@ import libs.global_value as g
 from integrations import factory
 from integrations.slack.events import comparison
 from libs.data import lookup
+from libs.types import ServiceType
 
 if TYPE_CHECKING:
     from integrations.discord.adapter import ServiceAdapter as discord_adapter
@@ -22,15 +23,15 @@ def main() -> None:
     g.cfg.initialization()
 
     # 結果の出力先(standard_io)
-    adapter_std = factory.select_adapter("standard_io", g.cfg)
+    adapter_std = factory.select_adapter(ServiceType.STANDARD_IO, g.cfg)
     m = adapter_std.parser()
 
     # 連携サービス切替
     match g.adapter.interface_type:
-        case "slack":
+        case ServiceType.SLACK:
             g.adapter = factory.select_adapter(g.adapter.interface_type, g.cfg)
             slack_comparison(m)
-        case "discord":
+        case ServiceType.DISCORD:
             g.adapter = factory.select_adapter(g.adapter.interface_type, g.cfg)
             discord_comparison(m)
         case _:

--- a/libs/global_value.py
+++ b/libs/global_value.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from integrations.standard_io.adapter import ServiceAdapter as std_adapter
     from integrations.web.adapter import ServiceAdapter as web_adapter
     from libs.bootstrap.app_config import AppConfig
-    from libs.types import Args
+    from libs.domain.datamodels import Args
 
 # --- グローバル変数 ---
 adapter: Union["slack_adapter", "discord_adapter", "web_adapter", "std_adapter"]

--- a/libs/types.py
+++ b/libs/types.py
@@ -64,6 +64,31 @@ class ChannelType(StrEnum):
     """未定義状態"""
 
 
+class CommandType(StrEnum):
+    """実行(する/した)サブコマンド県設定ファイルセクション名"""
+
+    RESULTS = "results"
+    """成績サマリ"""
+    GRAPH = "graph"
+    """グラフ生成"""
+    RANKING = "ranking"
+    """ランキング"""
+    RATING = "rating"
+    """レーティング"""
+    REPORT = "report"
+    """レポート"""
+    MEMBER_LIST = "member"
+    """メンバー一覧"""
+    TEAM_LIST = "team"
+    """チーム一覧"""
+    HELP = "help"
+    """ヘルプ"""
+    COMPARISON = "comparison"
+    """突合処理"""
+    UNKNOWN = "unknown"
+    """未定義"""
+
+
 class ServiceType(StrEnum):
     """連携先サービス"""
 

--- a/libs/types.py
+++ b/libs/types.py
@@ -21,6 +21,21 @@ MessageType: TypeAlias = Union[None, str, "Path", "pd.DataFrame"]
 """
 
 
+class MessageStatus(StrEnum):
+    """メッセージステータス"""
+
+    APPEND = "message_append"
+    """新規ポストイベント"""
+    CHANGED = "message_changed"
+    """編集イベント"""
+    DELETED = "message_deleted"
+    """削除イベント"""
+    DO_NOTHING = "do_nothing"
+    """何もしなくてよいイベント"""
+    UNDETERMINED = "undetermined"
+    """未定義状態"""
+
+
 class ServiceType(StrEnum):
     """連携先サービス"""
 

--- a/libs/types.py
+++ b/libs/types.py
@@ -105,42 +105,6 @@ class ServiceType(StrEnum):
 
 
 @dataclass
-class Args:
-    """コマンドラインオプション"""
-
-    service: str
-    config: "Path"
-    """設定ファイルパス"""
-
-    debug: int
-    """デバッグ出力フラグ"""
-    verbose: int
-    """詳細出力フラグ"""
-
-    moderate: bool
-    """INFO以下のログレベル出力を抑止"""
-    notime: bool
-    """ログに日付を付与しない"""
-
-    # Only allowed when --service=standard_io
-    text: str
-
-    # Only allowed when --service=web
-    host: str
-    port: int
-
-    # dbtools
-    compar: bool
-    unification: "Path"
-    recalculation: bool
-    export_data: str
-    import_data: str
-    vacuum: bool
-    gen_test_data: int
-    testcase: Optional["Path"]
-
-
-@dataclass
 class StyleOptions:
     """表示オプション"""
 

--- a/libs/types.py
+++ b/libs/types.py
@@ -3,7 +3,7 @@ libs/types.py
 """
 
 from dataclasses import asdict, dataclass, field
-from enum import Enum, auto
+from enum import Enum, StrEnum, auto
 from typing import TYPE_CHECKING, Any, Literal, Optional, TypeAlias, TypedDict, Union
 
 if TYPE_CHECKING:
@@ -19,6 +19,21 @@ MessageType: TypeAlias = Union[None, str, "Path", "pd.DataFrame"]
 - *Path*: ファイルパス(アップロード処理)
 - *DataFrame*: 表データ
 """
+
+
+class ServiceType(StrEnum):
+    """連携先サービス"""
+
+    SLACK = "slack"
+    """slack"""
+    DISCORD = "discord"
+    """discord"""
+    WEB = "web"
+    """web ui"""
+    STANDARD_IO = "standard_io"
+    """standard_io"""
+    UNKNOWN = "unknown"
+    """unknown"""
 
 
 @dataclass

--- a/libs/types.py
+++ b/libs/types.py
@@ -47,6 +47,23 @@ class ActionStatus(StrEnum):
     """何もしてない"""
 
 
+class ChannelType(StrEnum):
+    """チャンネルタイプ"""
+
+    CHANNEL = "normal"
+    """通常チャンネル"""
+    PRIVATE = "private"
+    """プライベートチャンネル"""
+    DIRECT_MESSAGE = "direct_message"
+    """ダイレクトメッセージ"""
+    HOME_APP = "home_app"
+    """Slackのホームアプリ"""
+    SEARCH = "search_api"
+    """検索API"""
+    UNDETERMINED = "undetermined"
+    """未定義状態"""
+
+
 class ServiceType(StrEnum):
     """連携先サービス"""
 

--- a/libs/types.py
+++ b/libs/types.py
@@ -36,6 +36,17 @@ class MessageStatus(StrEnum):
     """未定義状態"""
 
 
+class ActionStatus(StrEnum):
+    """DBに対する操作"""
+
+    CHANGE = "change"
+    """insert/updateが実行された"""
+    DELETE = "delete"
+    """deleteが実行された"""
+    NOTHING = "nothing"
+    """何もしてない"""
+
+
 class ServiceType(StrEnum):
     """連携先サービス"""
 

--- a/libs/utils/dictutil.py
+++ b/libs/utils/dictutil.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING, Any, Protocol
 import libs.global_value as g
 from libs.data import lookup
 from libs.domain.command import CommandParser
-from libs.domain.datamodels import ChannelType
 from libs.domain.placeholder import PlaceholderBuilder
+from libs.types import ChannelType
 from libs.utils import formatter
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 

--- a/tests/database/test_result_update.py
+++ b/tests/database/test_result_update.py
@@ -12,6 +12,7 @@ from integrations import factory
 from libs.bootstrap import configuration
 from libs.data import initialization, modify
 from libs.domain.score import GameResult
+from libs.types import ServiceType
 from libs.utils import dbutil, validator
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 from libs.utils.timekit import Format
@@ -29,8 +30,8 @@ def test_score_insert(draw_split: bool, game_result: str, get_point: dict[str, f
     configuration.setup(init_db=False)
     g.cfg.setting.database_file = "memdb1?mode=memory&cache=shared"  # DB差し替え
     initialization.setup_resultdb(g.cfg.setting.database_file)
-    g.adapter = factory.select_adapter("standard_io", g.cfg)
-    g.cfg.selected_service = "standard_io"
+    g.adapter = factory.select_adapter(ServiceType.STANDARD_IO, g.cfg)
+    g.cfg.selected_service = ServiceType.STANDARD_IO
 
     m = g.adapter.parser()
     m.data.text = game_result

--- a/tests/events/test_integrations_web.py
+++ b/tests/events/test_integrations_web.py
@@ -15,6 +15,7 @@ import libs.global_value as g
 from integrations import factory
 from integrations.web.events import create_bp
 from libs.bootstrap import configuration
+from libs.types import ServiceType
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -32,7 +33,7 @@ def client(request: pytest.FixtureRequest) -> Any:
     sys.argv = ["app.py", "--service=web", f"--config=tests/testdata/{config_path}"]
     configuration.setup(init_db=False)
 
-    adapter = factory.select_adapter("web", g.cfg)
+    adapter = factory.select_adapter(ServiceType.WEB, g.cfg)
 
     app = Flask(
         __name__,

--- a/tests/events/test_message_dispatch.py
+++ b/tests/events/test_message_dispatch.py
@@ -12,8 +12,7 @@ import libs.dispatcher
 import libs.global_value as g
 from integrations import factory
 from libs.bootstrap import configuration
-from libs.domain.datamodels import MessageStatus
-from libs.types import ServiceType
+from libs.types import MessageStatus, ServiceType
 from tests.events import param_data
 
 if TYPE_CHECKING:

--- a/tests/events/test_message_dispatch.py
+++ b/tests/events/test_message_dispatch.py
@@ -13,6 +13,7 @@ import libs.global_value as g
 from integrations import factory
 from libs.bootstrap import configuration
 from libs.domain.datamodels import MessageStatus
+from libs.types import ServiceType
 from tests.events import param_data
 
 if TYPE_CHECKING:
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 def _init() -> "MessageParserProtocol":
     """初期化処理"""
     configuration.setup(init_db=False)
-    adapter = factory.select_adapter("standard_io", g.cfg)
+    adapter = factory.select_adapter(ServiceType.STANDARD_IO, g.cfg)
     m = adapter.parser()
     m.status.command_flg = True
 

--- a/tests/events/test_slash_dispatch.py
+++ b/tests/events/test_slash_dispatch.py
@@ -12,7 +12,7 @@ import libs.dispatcher
 import libs.global_value as g
 from integrations import factory
 from libs.bootstrap import configuration
-from libs.types import StyleOptions
+from libs.types import ServiceType, StyleOptions
 from tests.events import param_data
 
 if TYPE_CHECKING:
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 def _init() -> "MessageParserProtocol":
     """初期化処理"""
     configuration.setup(init_db=False)
-    adapter = factory.select_adapter("standard_io", g.cfg)
+    adapter = factory.select_adapter(ServiceType.STANDARD_IO, g.cfg)
     m = adapter.parser()
     m.status.command_flg = True
 

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -12,6 +12,7 @@ from integrations import factory
 from integrations.standard_io.adapter import ServiceAdapter
 from libs.bootstrap import configuration
 from libs.domain.command import CommandParser
+from libs.types import ServiceType
 from libs.utils import dictutil
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 from tests.parser import param_data
@@ -27,7 +28,7 @@ def parser_instance() -> Generator[ServiceAdapter, Any, None]:
 
     configuration.setup(init_db=False)
 
-    adapter = factory.select_adapter("standard_io", g.cfg)
+    adapter = factory.select_adapter(ServiceType.STANDARD_IO, g.cfg)
 
     yield adapter
 

--- a/tests/parser/test_placeholder.py
+++ b/tests/parser/test_placeholder.py
@@ -12,6 +12,7 @@ from integrations import factory
 from integrations.standard_io.adapter import ServiceAdapter
 from libs.bootstrap import configuration
 from libs.data import lookup
+from libs.types import ServiceType
 from libs.utils import dictutil, formatter
 from tests.parser import param_data
 
@@ -27,7 +28,7 @@ def parser_instance() -> Generator[ServiceAdapter, Any, None]:
     configuration.setup(init_db=False)
     lookup.read_memberslist()
 
-    adapter = factory.select_adapter("standard_io", g.cfg)
+    adapter = factory.select_adapter(ServiceType.STANDARD_IO, g.cfg)
 
     yield adapter
 

--- a/tests/parser/test_score.py
+++ b/tests/parser/test_score.py
@@ -12,6 +12,7 @@ from integrations import factory
 from libs.bootstrap import configuration
 from libs.data import initialization
 from libs.domain.score import GameResult
+from libs.types import ServiceType
 from libs.utils import validator
 from tests.parser import param_data
 
@@ -27,8 +28,8 @@ def test_score_report(input_str: str, result_dict: dict[str, Any], get_point: di
     configuration.setup(init_db=False)
     g.cfg.setting.database_file = "memdb1?mode=memory&cache=shared"  # DB差し替え
     initialization.setup_resultdb(g.cfg.setting.database_file)
-    g.adapter = factory.select_adapter("standard_io", g.cfg)
-    g.cfg.selected_service = "standard_io"
+    g.adapter = factory.select_adapter(ServiceType.STANDARD_IO, g.cfg)
+    g.cfg.selected_service = ServiceType.STANDARD_IO
 
     m = g.adapter.parser()
     m.data.text = input_str
@@ -68,8 +69,8 @@ def test_point_calc_seat(rpoint_list: list[str], point_dict: dict[str, float], r
     configuration.setup(init_db=False)
     g.cfg.setting.database_file = "memdb1?mode=memory&cache=shared"  # DB差し替え
     initialization.setup_resultdb(g.cfg.setting.database_file)
-    g.adapter = factory.select_adapter("standard_io", g.cfg)
-    g.cfg.selected_service = "standard_io"
+    g.adapter = factory.select_adapter(ServiceType.STANDARD_IO, g.cfg)
+    g.cfg.selected_service = ServiceType.STANDARD_IO
 
     result = GameResult(
         ts="1234567890.123456",
@@ -107,8 +108,8 @@ def test_point_calc_division(rpoint_list: list[str], point_dict: dict[str, float
     configuration.setup(init_db=False)
     g.cfg.setting.database_file = "memdb1?mode=memory&cache=shared"  # DB差し替え
     initialization.setup_resultdb(g.cfg.setting.database_file)
-    g.adapter = factory.select_adapter("standard_io", g.cfg)
-    g.cfg.selected_service = "standard_io"
+    g.adapter = factory.select_adapter(ServiceType.STANDARD_IO, g.cfg)
+    g.cfg.selected_service = ServiceType.STANDARD_IO
 
     result = GameResult(
         ts="1234567890.123456",

--- a/tests/test.py
+++ b/tests/test.py
@@ -23,6 +23,7 @@ from libs.commands.ranking import ranking
 from libs.commands.report import stats_list, stats_report
 from libs.commands.results import summary as results_summary
 from libs.domain.command import CommandParser
+from libs.types import ServiceType
 from libs.utils import dictutil
 
 if TYPE_CHECKING:
@@ -86,7 +87,7 @@ def test_pattern(flag: dict[str, Any], test_case: str, sec: str, pattern: str, a
         )
 
     # ---------------------------------------------------------------------------------------------
-    adapter = factory.select_adapter("standard_io", g.cfg)
+    adapter = factory.select_adapter(ServiceType.STANDARD_IO, g.cfg)
     m = adapter.parser()
     target_loop: list[str] = []
 


### PR DESCRIPTION
This pull request refactors the codebase to standardize the use of the `ServiceType` enum instead of string literals for identifying services, and consolidates several type imports from `libs.domain.datamodels` into `libs.types`. This improves type safety, code clarity, and maintainability across all integrations and adapters.

**Service type handling and adapter selection:**

* Replaced string-based service identifiers (e.g., `"slack"`, `"discord"`) with the `ServiceType` enum throughout the codebase, including in all adapter classes, the main application logic in `app.py`, and the adapter selection logic in `integrations/factory.py`. This also includes updating type annotations and overloads for the `select_adapter` function to use `ServiceType`. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R33) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L45-R58) [[3]](diffhunk://#diff-a8d3389f8d5bf42a5293be9697fe2cc27cf858d988f3926604e7d54dbb77e596L5-R16) [[4]](diffhunk://#diff-a8d3389f8d5bf42a5293be9697fe2cc27cf858d988f3926604e7d54dbb77e596L25-R55) [[5]](diffhunk://#diff-a8d3389f8d5bf42a5293be9697fe2cc27cf858d988f3926604e7d54dbb77e596L56-R72) [[6]](diffhunk://#diff-39a3160649d575c22ef1a69752a8663d938c8fe4757a802133790c77b60abc26R12) [[7]](diffhunk://#diff-39a3160649d575c22ef1a69752a8663d938c8fe4757a802133790c77b60abc26L20-R21) [[8]](diffhunk://#diff-281b82a6d6c5f83439e0cac485dd0287a133c0f9e99dbe322d6bc8f97f019d3eR12) [[9]](diffhunk://#diff-281b82a6d6c5f83439e0cac485dd0287a133c0f9e99dbe322d6bc8f97f019d3eL20-R21) [[10]](diffhunk://#diff-9f693e69cc1ad2d908da4b969daae5da5251d8e6b491032ebbc5872e52d04fddR12) [[11]](diffhunk://#diff-9f693e69cc1ad2d908da4b969daae5da5251d8e6b491032ebbc5872e52d04fddL20-R21) [[12]](diffhunk://#diff-d5bfa4ac4733eca6dc1e2bc71fb6cd5f984f97aa3d9abf11d1c351ab7e0459a4R12) [[13]](diffhunk://#diff-d5bfa4ac4733eca6dc1e2bc71fb6cd5f984f97aa3d9abf11d1c351ab7e0459a4L20-R21)

**Type import consolidation:**

* Moved imports of commonly used types such as `ActionStatus`, `CommandType`, `ChannelType`, `MessageStatus`, `RemarkDict`, and `StyleOptions` from `libs.domain.datamodels` to `libs.types` in all affected files, including Discord and Slack integrations and protocol definitions. [[1]](diffhunk://#diff-e70f2c4ac2e5530abf5bae8dede764a1abe586aec1781fb4dd21c822d3828c7bL16-R16) [[2]](diffhunk://#diff-dbe08a2e2ba59bcf3e91478b11948a38136080e684d2f299f31282b0d0460ee6L15-R17) [[3]](diffhunk://#diff-370bd60fbc83a3f76ea9b745e643db23053f78d2dccbec800b05b5b8d570610aL12-R12) [[4]](diffhunk://#diff-f8f1eb9e16368a63e337c09b04697116a1569feb35ca55b16ccba128d064903fL11-R11) [[5]](diffhunk://#diff-6d058926728a6b11a635dd4b83e5f144b17c3cd4a12b41681963950479211475L13-R13) [[6]](diffhunk://#diff-3cd8ccde9a0511cf3d2e96e9288a7cfa5df845fd911a6aa564cd92a2f5ff7a68L8-R8) [[7]](diffhunk://#diff-15aefd5123d19b186d8d9a71ece2a26a72bfbecb3ce74bcbad19f684cadd2939L10-R12) [[8]](diffhunk://#diff-110dedcbd8762e9c4a5c1def1ed8cc7f118adb2a8afce710c68a6047b5c12c9dL13-R13) [[9]](diffhunk://#diff-98fec2643e2da9d619885c3254256a2914a1bfcc9eecf8d91bab5c084d074155L13-R13) [[10]](diffhunk://#diff-8c2643c908331a43430aedfa9a5c3f006959b1c0c29feb975cf45ece8830b8d7L15-R15) [[11]](diffhunk://#diff-23baa78319a7052e993f6ca661ab309cf3f43dbcdf2e2ab0782ddb859f0adec0L13-R13) [[12]](diffhunk://#diff-cef30475cb7daff0cdd5651691253c9f22bf28fbaa91336867c2dca24cfa7d44L11-R11) [[13]](diffhunk://#diff-8210fd02189a56ec626b50250ffecb24f0cc98ce16b46ebda41721243e282e97L11-R11) [[14]](diffhunk://#diff-58cb6902680c277861a8021d722f188a8ee3ef2b7c201c92d9c1741557064801L10-R10)

These changes collectively improve the robustness and consistency of service selection, adapter instantiation, and type usage across the project.