### PR TITLE
Refactor test functions to use dynamic keyword retrieval from configu…

### DIFF
--- a/tests/parser/test_placeholder.py
+++ b/tests/parser/test_placeholder.py
@@ -59,8 +59,9 @@ def test_command_check(input_args: str, player_name: str, player_list: list[str]
 )
 def test_player_check(input_args: str, player_name: str, player_list: list[str], competition_list: list[str], parser_instance: Any) -> None:
     """プレイヤー名"""
+    keyword = list(g.cfg.rule.keyword_mapping.keys())[0]
     m = cast(ServiceAdapter, parser_instance).parser()
-    m.parser({"text": f"{g.cfg.setting.keyword} {input_args}"})
+    m.parser({"text": f"{keyword} {input_args}"})
     param = dictutil.placeholder(g.cfg.results, m)
 
     print(f"\n  --> in: {input_args.split()} out: {param}")
@@ -76,8 +77,9 @@ def test_player_check(input_args: str, player_name: str, player_list: list[str],
 )
 def test_team_check(input_args: str, player_name: str, player_list: list[str], competition_list: list[str], parser_instance: Any) -> None:
     """チーム名"""
+    keyword = list(g.cfg.rule.keyword_mapping.keys())[0]
     m = cast(ServiceAdapter, parser_instance).parser()
-    m.parser({"event": {"text": f"{g.cfg.setting.keyword} {input_args}"}})
+    m.parser({"event": {"text": f"{keyword} {input_args}"}})
     param = dictutil.placeholder(g.cfg.results, m)
 
     print(f"\n  --> in: {input_args.split()} out: {param}")
@@ -93,8 +95,9 @@ def test_team_check(input_args: str, player_name: str, player_list: list[str], c
 )
 def test_guest_check(input_args: str, player_name: str, replace_name: str, parser_instance: Any) -> None:
     """ゲストチェック"""
+    keyword = list(g.cfg.rule.keyword_mapping.keys())[0]
     m = cast(ServiceAdapter, parser_instance).parser()
-    m.parser({"text": f"{g.cfg.setting.keyword} {input_args}"})
+    m.parser({"text": f"{keyword} {input_args}"})
     g.params = dictutil.placeholder(g.cfg.results, m)
 
     parsed_name = g.params.player_name


### PR DESCRIPTION
This pull request updates the test cases in `tests/parser/test_placeholder.py` to use the first keyword from the `keyword_mapping` configuration instead of a fixed keyword from `g.cfg.setting.keyword`. This makes the tests more robust and aligned with the current configuration.

**Test improvements:**

* Updated the `test_player_check` function to use the first key from `g.cfg.rule.keyword_mapping` when constructing the test input, instead of `g.cfg.setting.keyword`.
* Updated the `test_team_check` function similarly, ensuring the event text uses the current configuration's keyword.
* Updated the `test_guest_check` function to use the first keyword from `keyword_mapping` for test input construction.…ration