### PR TITLE
Develop

### DIFF
--- a/libs/bootstrap/configuration.py
+++ b/libs/bootstrap/configuration.py
@@ -283,16 +283,6 @@ def setup(init_db: bool = True) -> None:
 
     register()
 
-    # メモ記録ワード登録
-    if g.cfg.setting.remarks_suffix:
-        for rule_version in g.cfg.rule.rule_list:
-            keywords = [word for word, rule in g.cfg.rule.keyword_mapping.items() if rule == rule_version]
-            if keywords:
-                g.cfg.rule.data[rule_version].remarks_words.extend([f"{rule}{suffix}" for rule in keywords for suffix in g.cfg.setting.remarks_suffix])
-    else:
-        for rule_version in g.cfg.rule.rule_list:
-            g.cfg.rule.data[rule_version].remarks_words.append(g.cfg.setting.remarks_word)
-
     # キーワード重複チェック
     g.cfg.rule.check(
         chk_commands=set(

--- a/libs/bootstrap/initialization.py
+++ b/libs/bootstrap/initialization.py
@@ -165,17 +165,8 @@ def setup_rule_data() -> None:
                 g.cfg.rule.keyword_mapping.update({keyword: rule_version})
 
     g.cfg.rule.status_update(g.params.placeholder())
+    g.cfg.rule.remarks_words_update(g.cfg.setting.remarks_suffix)
     g.cfg.rule.register_to_database()
-
-    # メモ記録ワード登録
-    if g.cfg.setting.remarks_suffix:
-        for rule_version in g.cfg.rule.rule_list:
-            keywords = [word for word, rule in g.cfg.rule.keyword_mapping.items() if rule == rule_version]
-            if keywords:
-                g.cfg.rule.data[rule_version].remarks_words.extend([f"{rule}{suffix}" for rule in keywords for suffix in g.cfg.setting.remarks_suffix])
-    else:
-        for rule_version in g.cfg.rule.rule_list:
-            g.cfg.rule.data[rule_version].remarks_words.append(g.cfg.setting.remarks_word)
 
 
 def setup_regulations(database_file: Union[str, Path]) -> None:

--- a/libs/bootstrap/initialization.py
+++ b/libs/bootstrap/initialization.py
@@ -167,6 +167,16 @@ def setup_rule_data() -> None:
     g.cfg.rule.status_update(g.params.placeholder())
     g.cfg.rule.register_to_database()
 
+    # メモ記録ワード登録
+    if g.cfg.setting.remarks_suffix:
+        for rule_version in g.cfg.rule.rule_list:
+            keywords = [word for word, rule in g.cfg.rule.keyword_mapping.items() if rule == rule_version]
+            if keywords:
+                g.cfg.rule.data[rule_version].remarks_words.extend([f"{rule}{suffix}" for rule in keywords for suffix in g.cfg.setting.remarks_suffix])
+    else:
+        for rule_version in g.cfg.rule.rule_list:
+            g.cfg.rule.data[rule_version].remarks_words.append(g.cfg.setting.remarks_word)
+
 
 def setup_regulations(database_file: Union[str, Path]) -> None:
     """

--- a/libs/commands/help/entry.py
+++ b/libs/commands/help/entry.py
@@ -126,7 +126,7 @@ def help_message(m: "MessageParserProtocol") -> None:
     m.set_message(
         textwrap.dedent(f"""\
         使い方：<メモ記録ワード> <対象メンバー> <内容>
-        メモ記録ワード：{"、".join(g.cfg.rule.data[g.params.rule_version].remarks_words)}
+        メモ記録ワード：{"、".join(g.cfg.rule.data[g.params.rule_version].remarks)}
 
         {remarks_type1}
         {remarks_type0}

--- a/libs/domain/rule.py
+++ b/libs/domain/rule.py
@@ -47,7 +47,7 @@ class RuleData:
     """未定義ワードタイプ"""
     keywords: list[str] = field(default_factory=list)
     """成績記録キーワード"""
-    remarks_words: list[str] = field(default_factory=list)
+    remarks: list[str] = field(default_factory=list)
     """メモ記録用ワード"""
     dropitems: list[str] = field(default_factory=list)
     """非表示にする項目"""
@@ -94,7 +94,7 @@ class RuleData:
                 else:
                     setattr(self, item, str(flag).lower() in {"1", "true", "yes", "on"})
 
-        for item in ["keywords", "remarks_words", "dropitems"]:
+        for item in ["keywords", "remarks", "dropitems"]:
             if item_list := rule_data.get(item):
                 if isinstance(item_list, str):
                     setattr(self, item, [x.strip() for x in item_list.split(",")])
@@ -112,6 +112,8 @@ class RuleSet:
         """ルール情報格納辞書"""
         self.keyword_mapping: dict[str, str] = {}
         """登録キーワードとルール識別子のマッピング"""
+        self.remarks_words: list[str] = []
+        """メモ記録用ワードリスト"""
 
     def data_set(self, section_name: str, rule_data: Mapping[str, Any]) -> None:
         """
@@ -197,6 +199,27 @@ class RuleSet:
                     self.data[rule_version].first_time = ExtDt(float(status_data["first_time"]))
                 if "last_time" in status_data:
                     self.data[rule_version].last_time = ExtDt(float(status_data["last_time"]))
+
+    def remarks_words_update(self, suffix: list[str]) -> None:
+        """
+        メモ記録ワードリストを更新する
+
+        Args:
+            suffix (list[str]): メモに追加するサフィックス
+
+        """
+        ret: list[str] = []
+
+        for rule in self.rule_list:
+            if rule_data := self.data.get(rule):
+                if rule_data.remarks:
+                    ret.extend(rule_data.remarks)
+                else:
+                    ret.extend(
+                        [f"{pre}{suf}" for pre in self.keywords(rule) for suf in suffix],
+                    )
+
+        self.remarks_words = list(set(ret))
 
     def to_dict(self, rule_version: str) -> dict[str, Any]:
         """
@@ -470,19 +493,3 @@ class RuleSet:
 
         """
         return [x.rule_version for x in self.data.values()]
-
-    @property
-    def remarks_words(self) -> list[str]:
-        """
-        全ルールセットのメモ記録ワードを列挙
-
-        Returns:
-            list[str]: メモ記録ワード
-
-        """
-        ret: list[str] = []
-
-        for rule, data in self.data.items():
-            ret.extend(data.remarks_words)
-
-        return list(set(ret))

--- a/libs/domain/rule.py
+++ b/libs/domain/rule.py
@@ -390,7 +390,10 @@ class RuleSet:
                 rule.ignore_flying,
                 rule.undefined_word,
             )
-
+        if self.remarks_words:
+            logging.info("remarks_words: %s", self.remarks_words)
+        else:
+            logging.warning("remarks_words: empty")
         if self.keyword_mapping:
             logging.info("keyword_mapping: %s", self.keyword_mapping)
         else:


### PR DESCRIPTION
This pull request refactors how memo remark keywords ("remarks words") are managed and accessed throughout the codebase. The main change is the unification and renaming of the remarks keyword list from `remarks_words` to `remarks`, with a new centralized method for updating and retrieving all remark keywords. This simplifies the logic, reduces duplication, and clarifies the data flow for memo remark keywords.

**Refactoring and Unification of Remarks Keywords:**

* Renamed the `remarks_words` attribute in the `RuleData` class to `remarks` and updated all references accordingly for consistency. [[1]](diffhunk://#diff-05175ba2abccf7c80dd601ce59a856abfa549ff65da04999d48dfcef54b12efbL50-R50) [[2]](diffhunk://#diff-05175ba2abccf7c80dd601ce59a856abfa549ff65da04999d48dfcef54b12efbL97-R97)
* Removed the `remarks_words` property method in the `Rule` class and replaced it with a new method `remarks_words_update`, which centralizes the logic for updating the list of all memo remark keywords across rules. [[1]](diffhunk://#diff-05175ba2abccf7c80dd601ce59a856abfa549ff65da04999d48dfcef54b12efbL470-L485) [[2]](diffhunk://#diff-05175ba2abccf7c80dd601ce59a856abfa549ff65da04999d48dfcef54b12efbR203-R223)
* Updated the `setup_rule_data` function to call the new `remarks_words_update` method after rule data initialization, ensuring the remarks list is always up to date.
* Removed the previous logic for setting up remarks keywords from `setup` in `configuration.py` since this is now handled by the new centralized method.

**Codebase Consistency and Logging Improvements:**

* Updated logging in the `info` method to log the new `remarks_words` attribute, providing better visibility into the current set of memo remark keywords.
* Updated help message formatting to use the unified `remarks` attribute for displaying available memo remark keywords to users.
* Added a `remarks_words` attribute to the `Rule` class to store the up-to-date list of all memo remark keywords for easier access throughout the application.