### PR TITLE
Add score comparison handling in summary handler

### DIFF
--- a/integrations/slack/events/home_tab/summary.py
+++ b/integrations/slack/events/home_tab/summary.py
@@ -151,8 +151,12 @@ def register_summary_handlers(app: "App", adapter: ServiceAdapter) -> None:
                 rating.aggregation(m)
                 adapter.api.post(m)
             case _:
-                m.status.command_type = CommandType.RESULTS
-                results_summary.aggregation(m)
+                if g.params.score_comparisons:
+                    m.status.command_type = CommandType.COMPARISON
+                    results_summary.difference(m)
+                else:
+                    m.status.command_type = CommandType.RESULTS
+                    results_summary.aggregation(m)
                 adapter.api.post(m)
 
         ui_parts.update_view(adapter, m, app_msg)


### PR DESCRIPTION
This pull request introduces a conditional check to enhance how aggregation actions are handled in the Slack home tab summary. The main improvement is that when score comparisons are enabled, the system now processes and posts a comparison summary instead of a standard aggregation summary.

**Enhancement to aggregation action handling:**

* Added a conditional branch in `handle_aggregation_action` (in `summary.py`) to check if `score_comparisons` is enabled; if so, it sets the command type to `COMPARISON` and calls `results_summary.difference(m)`, otherwise it retains the existing aggregation logic.