### PR TITLE
Develop

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,16 +23,15 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
-      - name: Generate documentation
+      - name: Generate documentation for sphinx
         run: |
-          rm -rf temp_docs
-          uv run pdoc -d google --logo https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEig6avYSN3Ds4H-e_Hib-mB6bYwDH71xSD7vn22M6QVjtzMei0d6T29PZYPOQadAs6AqUe4dzFo4lLhN6gpKCJHugZd5rQdF8m5oXt2BL1gZAv11YQey7bds63cuhP0gFqQwk4hF9yV28sE/s128/ma-jan_pai.png --logo-link '' --output-dir temp_docs *.py libs integrations
-          touch temp_docs/.nojekyll
-        env:
-          PDOC_ALLOW_EXEC: "1"
+          rm -rf temp_docs_sphinx
+          uv run sphinx-apidoc -f -o ./temp_docs_sphinx/source/ . -d 2 --tocfile=index --module-first --separate
+          uv run sphinx-build -M html ./temp_docs_sphinx/source/ ./temp_docs_sphinx/build --conf-dir docs/dev/
+          touch temp_docs_sphinx/.nojekyll
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./temp_docs
+          publish_dir: ./temp_docs_sphinx/html/

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ backup/
 *.css
 docs/html/
 docs/cov/
+docs/dev/build/
+docs/dev/source/
 
 !requirements.txt
 !files/**

--- a/docs/dev/conf.py
+++ b/docs/dev/conf.py
@@ -1,0 +1,33 @@
+"""
+Configuration file for the Sphinx documentation builder.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../"))
+
+# -- Project information -----------------------------------------------------
+project = "Mahjong score management tool"
+copyright = "2026, togakushi"
+author = "togakushi"
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+]
+
+templates_path = ["templates"]
+exclude_patterns = []
+
+# -- Options for autodoc ----------------------------------------------------
+autodoc_typehints = "description"
+autodoc_class_signature = "separated"
+
+# -- Napoleon settings ------------------------------------------------------
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+
+# -- Options for HTML output -------------------------------------------------
+html_theme = "python_docs_theme"

--- a/docs/dev/templates/layout.html
+++ b/docs/dev/templates/layout.html
@@ -1,0 +1,60 @@
+{% extends "!layout.html" %}
+
+{%- macro relbar() %}
+{# modified from sphinx/themes/basic/layout.html #}
+    <div class="related" role="navigation" aria-label="related navigation">
+      <h3>{{ _('Navigation') }}</h3>
+      <ul>
+          {%- for rellink in rellinks %}
+          <li class="right" {% if loop.first %}style="margin-right: 10px"{% endif %}>
+              <a href="{{ pathto(rellink[0])|e }}" title="{{ rellink[1]|striptags|e }}"
+                 {{ accesskey(rellink[2]) }}>{{ rellink[3] }}
+              </a>
+              {%- if not loop.first %}{{ reldelim2 }}{% endif %}
+          </li>
+          {%- endfor %}
+          {%- block rootrellink %}
+          <li class="switchers">
+            <div class="language_switcher_placeholder"></div>
+            <div class="version_switcher_placeholder"></div>
+          </li>
+          <li>
+              {% if theme_root_include_title %}
+              <a href="{{ pathto('index') }}">{{ shorttitle }}</a>{{ reldelim1 }}
+              {% endif %}
+          </li>
+          {%- endblock %}
+            {%- for parent in parents %}
+                <li class="nav-item nav-item-{{ loop.index }}"><a href="{{ parent.link|e }}" {% if loop.last %}{{ accesskey("U") }}{% endif %}>{{ parent.title }}</a>{{ reldelim1 }}</li>
+                {%- endfor %}
+                <li class="nav-item nav-item-this"><a href="{{ link|e }}">{{ title }}</a></li>
+            {% block relbaritems %}
+            {%- if pagename != "search" and builder != "singlehtml" and builder != "htmlhelp" %}
+                <li class="right">
+                    {{ searchbox() }}
+                    {{ reldelim2 }}
+                </li>
+            {%- endif %}
+            <li class="right">{{ themeselector() }}{{ reldelim2 }}</li>
+            {% endblock %}
+      </ul>
+    </div>
+{%- endmacro %}
+
+{% block footer %}
+    <div class="footer">
+    &copy; {% if theme_copyright_url or hasdoc('copyright') -%}
+      <a href="{% if theme_copyright_url %}{{ theme_copyright_url }}{% else %}{{ pathto('copyright') }}{% endif %}">
+    {%- endif -%}
+    {%- trans %}Copyright{% endtrans -%}
+    {%- if theme_copyright_url or hasdoc('copyright') -%}
+    </a>
+    {%- endif %} {{ copyright|e }}.
+    {%- if last_updated %}
+      {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
+    {%- endif %}
+    {% if theme_issues_url %}
+      {% trans %}<a href="{{ theme_issues_url }}">Found a bug</a>?{% endtrans %}
+    {% endif %}
+    </div>
+{% endblock %}

--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -1,14 +1,16 @@
 """
 統合インターフェース定義
 
-Exports:
+Subpackages:
+
 - `integrations.base`: 抽象基底クラス
 - `integrations.slack`: slackインターフェース
 - `integrations.discord`: discordインターフェース
 - `integrations.web`: webインターフェース
 - `integrations.standard_io`: 標準入出力インターフェース
 
-モジュール:
+Submodules:
+
 - `integrations.factory`: インターフェースセレクター
 - `integrations.protocols`: プロトコル定義
 """

--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -2,16 +2,19 @@
 ライブラリ/モジュール
 
 アプリケーションライブラリ:
+
 - `libs.bootstrap`: アプリケーション起動処理
 - `libs.domain`: アプリケーションロジック
 - `libs.commands`: サブコマンド
 
 アプリケーションモジュール:
+
 - `libs.types`: 共通型定義
 - `libs.global_value`: モジュール間共通変数
 - `libs.dispatcher`: コマンドディスパッチャ
 
 共有ライブラリ:
+
 - `libs.functions`: 共通処理ライブラリ
 - `libs.utils`: ユーティリティ
 """

--- a/libs/bootstrap/section.py
+++ b/libs/bootstrap/section.py
@@ -3,6 +3,7 @@ libs/bootstrap/section.py
 """
 
 import logging
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, TypeAlias, Union
 
@@ -188,64 +189,45 @@ class BaseSection(CommonMethodMixin):
         return ret_dict
 
 
+@dataclass
 class SettingSection(BaseSection):
     """settingセクション処理"""
 
-    remarks_word: str
+    section: str = "setting"
+    """セクション名"""
+    remarks_word: str = field(default="麻雀メモ")
     """メモ記録用キーワード"""
-    remarks_suffix: list[str]
+    remarks_suffix: list[str] = field(default_factory=list)
     """メモ記録用キーワードサフィックス"""
-    rule_config: Optional[Path]
+    rule_config: Optional[Path] = field(default=None)
     """ルール設定ファイル"""
-    default_rule: str
+    default_rule: str = field(default="")
     """ルール識別子未指定時に使用される識別子"""
-    separate: bool
+    separate: bool = field(default=False)
     """スコア入力元識別子別集計フラグ
     - *True*: 識別子別に集計
     - *False*: すべて集計
     """
-    channel_id: Optional[str]
+    channel_id: Optional[str] = field(default=None)
     """チャンネルIDを上書きする"""
-    time_adjust: int
+    time_adjust: int = field(default=12)
     """日付変更後、集計範囲に含める追加時間"""
-    search_word: str
+    search_word: str = field(default="")
     """コメント固定(検索時の検索文字列)"""
-    group_length: int
+    group_length: int = field(default=0)
     """コメント固定(検索時の集約文字数)"""
-    guest_mark: str
+    guest_mark: str = field(default="※")
     """ゲスト無効時に未登録メンバーに付与する印"""
-    database_file: Union[str, Path]
+    database_file: Union[str, Path] = field(default=Path("mahjong.db"))
     """成績管理データベースファイル名"""
-    backup_dir: Optional[Path]
+    backup_dir: Optional[Path] = field(default=None)
     """バックアップ先ディレクトリ"""
-    font_file: Path
+    font_file: Path = field(default=Path("ipaexg.ttf"))
     """グラフ描写に使用するフォントファイル"""
-    graph_style: str
+    graph_style: str = field(default="ggplot")
     """グラフスタイル"""
-    work_dir: Path
+    work_dir: Path = field(default=Path("work"))
     """作業ディレクトリ"""
-
-    def __init__(self) -> None:
-        self.section: str = "setting"
-        self.default_reset()
-
-    def default_reset(self) -> None:
-        """パラメータ初期化"""
-        self.remarks_word = str("麻雀メモ")
-        self.remarks_suffix = []
-        self.rule_config = None
-        self.time_adjust = int(12)
-        self.default_rule = str("")
-        self.separate = bool(False)
-        self.channel_id = None
-        self.search_word = str("")
-        self.group_length = int(0)
-        self.guest_mark = str("※")
-        self.database_file = Path("mahjong.db")
-        self.backup_dir = None
-        self.font_file = Path("ipaexg.ttf")
-        self.graph_style = str("ggplot")
-        self.work_dir = Path("work")
 
 
 class AliasSection(BaseSection):

--- a/libs/bootstrap/section.py
+++ b/libs/bootstrap/section.py
@@ -230,50 +230,32 @@ class SettingSection(BaseSection):
     """作業ディレクトリ"""
 
 
+@dataclass
 class AliasSection(BaseSection):
     """aliasセクション処理"""
 
-    results: list[str]
+    section: str = "alias"
+    """セクション名"""
+    results: list[str] = field(default_factory=lambda: ["results", "成績"])
     """成績サマリ出力コマンド"""
-    graph: list[str]
+    graph: list[str] = field(default_factory=lambda: ["graph", "グラフ"])
     """成績グラフ出力コマンド"""
-    ranking: list[str]
+    ranking: list[str] = field(default_factory=lambda: ["ranking", "ランキング"])
     """ランキング出力コマンド"""
-    report: list[str]
+    report: list[str] = field(default_factory=lambda: ["report", "レポート"])
     """レポート出力コマンド"""
-    download: list[str]
-    member: list[str]
+    download: list[str] = field(default_factory=lambda: ["download", "ダウンロード"])
+    member: list[str] = field(default_factory=lambda: ["member", "userlist", "member_list"])
     """メンバーリスト表示コマンド"""
-    add: list[str]
-    delete: list[str]
-    team_create: list[str]
-    team_del: list[str]
-    team_add: list[str]
-    team_remove: list[str]
-    team_list: list[str]
+    add: list[str] = field(default_factory=lambda: ["add"])
+    delete: list[str] = field(default_factory=lambda: ["del"])
+    team_create: list[str] = field(default_factory=lambda: ["team_create"])
+    team_del: list[str] = field(default_factory=lambda: ["team_del"])
+    team_add: list[str] = field(default_factory=lambda: ["team_add"])
+    team_remove: list[str] = field(default_factory=lambda: ["team_remove"])
+    team_list: list[str] = field(default_factory=lambda: ["team_list"])
     """チームリスト出力コマンド"""
-    team_clear: list[str]
-
-    def __init__(self) -> None:
-        self.section = "alias"
-        self.default_reset()
-
-    def default_reset(self) -> None:
-        """パラメータ初期化"""
-        self.results = ["results", "成績"]
-        self.graph = ["graph", "グラフ"]
-        self.ranking = ["ranking", "ランキング"]
-        self.report = ["report", "レポート"]
-        self.download = ["download", "ダウンロード"]
-        self.member = ["member", "userlist", "member_list"]
-        self.add = ["add"]
-        self.delete = ["del"]
-        self.team_create = ["team_create"]
-        self.team_del = ["team_del"]
-        self.team_add = ["team_add"]
-        self.team_remove = ["team_remove"]
-        self.team_list = ["team_list"]
-        self.team_clear = ["team_clear"]
+    team_clear: list[str] = field(default_factory=lambda: ["team_clear"])
 
     def _after_config_load(self, _section_proxy: "SectionProxy") -> None:
         """AliasSection専用の追加処理"""

--- a/libs/bootstrap/section.py
+++ b/libs/bootstrap/section.py
@@ -245,17 +245,25 @@ class AliasSection(BaseSection):
     report: list[str] = field(default_factory=lambda: ["report", "レポート"])
     """レポート出力コマンド"""
     download: list[str] = field(default_factory=lambda: ["download", "ダウンロード"])
+    """DBダウンロードコマンド"""
     member: list[str] = field(default_factory=lambda: ["member", "userlist", "member_list"])
     """メンバーリスト表示コマンド"""
     add: list[str] = field(default_factory=lambda: ["add"])
+    """メンバー追加コマンド"""
     delete: list[str] = field(default_factory=lambda: ["del"])
+    """メンバー削除コマンド"""
     team_create: list[str] = field(default_factory=lambda: ["team_create"])
+    """チーム作成コマンド"""
     team_del: list[str] = field(default_factory=lambda: ["team_del"])
+    """チーム削除コマンド"""
     team_add: list[str] = field(default_factory=lambda: ["team_add"])
+    """チーム所属コマンド"""
     team_remove: list[str] = field(default_factory=lambda: ["team_remove"])
+    """チーム脱退コマンド"""
     team_list: list[str] = field(default_factory=lambda: ["team_list"])
     """チームリスト出力コマンド"""
     team_clear: list[str] = field(default_factory=lambda: ["team_clear"])
+    """全チーム情報削除コマンド"""
 
     def _after_config_load(self, _section_proxy: "SectionProxy") -> None:
         """AliasSection専用の追加処理"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mahjong-score-management"
-version = "0.12.2"
+version = "0.13.0"
 description = "Mahjong score management tool"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "pdoc",
+    "sphinx",
+    "python-docs-theme",
     "pytest",
     "pytest-cov",
     "mypy",

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,8 +8,9 @@ update:
 # --
 .PHONY: docs
 docs:
-	rm -rf docs/html
-	uv run pdoc -d google --output-dir docs/html --logo '' --logo-link '' *.py libs integrations tests
+	rm -rf docs/dev/source/
+	uv run sphinx-apidoc -f -o docs/dev/source/ . -d 2 --tocfile=index --module-first --separate
+	uv run sphinx-build -M html docs/dev/source/ docs/dev/build --conf-dir docs/dev/
 
 prospector:
 	@uv run prospector -W mccabe ..


### PR DESCRIPTION
This pull request migrates the project's documentation generation from `pdoc` to Sphinx, introduces a custom Sphinx configuration and theme, and refactors the `SettingSection` and `AliasSection` classes to use Python's `@dataclass` for cleaner and more maintainable code. Additionally, the project version is bumped to `0.13.0`, and minor docstring clarifications are made in some `__init__.py` files.

**Documentation System Migration and Improvements:**

* Switched documentation generation from `pdoc` to Sphinx in the GitHub Actions workflow, updating the build and deployment steps to use Sphinx commands and output directories. (`.github/workflows/docs.yml`)
* Added a custom Sphinx configuration file `conf.py` with project metadata, extensions, and theme settings. (`docs/dev/conf.py`)
* Introduced a custom Sphinx HTML template for layout customization. (`docs/dev/templates/layout.html`)
* Updated the Makefile to use Sphinx for local documentation builds instead of `pdoc`. (`tests/Makefile`)
* Updated development dependencies to include `sphinx` and `python-docs-theme` instead of `pdoc`. (`pyproject.toml`)

**Codebase Refactoring:**

* Refactored `SettingSection` and `AliasSection` in `libs/bootstrap/section.py` to use `@dataclass` with default values and `field(default_factory=...)`, removing manual initialization logic for improved clarity and maintainability. (`libs/bootstrap/section.py`)

**Project Metadata:**

* Bumped the project version to `0.13.0` to reflect these significant changes. (`pyproject.toml`)

**Minor Documentation Updates:**

* Clarified the meaning of "Subpackages" and "Submodules" in `integrations/__init__.py` and added similar clarifications in `libs/__init__.py`. [[1]](diffhunk://#diff-81f6e359a89038e05c019a02fef999e74271aa1405b070fcd7185d3c1c0a0defL4-R13) [[2]](diffhunk://#diff-70f064535807ecc7ceb7c9bd7403eb3abdf8e9e7225421522bb8801a2dbf4ecfR5-R17)
* Minor import cleanup in `libs/bootstrap/section.py`.