### PR TITLE
Fix documentation build process by updating publish directory and add…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,10 +28,9 @@ jobs:
           rm -rf temp_docs_sphinx
           uv run sphinx-apidoc -f -o ./temp_docs_sphinx/source/ . -d 2 --tocfile=index --module-first --separate
           uv run sphinx-build -M html ./temp_docs_sphinx/source/ ./temp_docs_sphinx/build --conf-dir docs/dev/
-          touch temp_docs_sphinx/.nojekyll
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./temp_docs_sphinx/html/
+          publish_dir: ./temp_docs_sphinx/build/html/

--- a/docs/dev/conf.py
+++ b/docs/dev/conf.py
@@ -16,6 +16,7 @@ author = "togakushi"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "sphinx.ext.githubpages",
 ]
 
 templates_path = ["templates"]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,6 +10,7 @@ update:
 docs:
 	rm -rf docs/dev/source/
 	uv run sphinx-apidoc -f -o docs/dev/source/ . -d 2 --tocfile=index --module-first --separate
+	uv run sphinx-build -M clean docs/dev/source/ docs/dev/build --conf-dir docs/dev/
 	uv run sphinx-build -M html docs/dev/source/ docs/dev/build --conf-dir docs/dev/
 
 prospector:


### PR DESCRIPTION
This pull request updates the Sphinx documentation build and deployment workflow to improve compatibility with GitHub Pages and ensure a cleaner build process. The key changes involve modifying the Sphinx configuration, updating the build and deployment directories, and improving the Makefile for docs.

**Documentation build and deployment improvements:**

* Added the `sphinx.ext.githubpages` extension to `docs/dev/conf.py` to improve compatibility with GitHub Pages by automatically creating a `.nojekyll` file.
* Updated the GitHub Actions workflow to deploy from `temp_docs_sphinx/build/html/` instead of the incorrect `temp_docs_sphinx/html/` directory, ensuring the correct documentation files are published.
* Removed the manual creation of the `.nojekyll` file in the workflow since the Sphinx extension now handles this.

**Build process enhancements:**

* Updated the `docs` target in `tests/Makefile` to clean the previous build before generating new HTML documentation, ensuring that stale files are removed and the build is fresh.…ing clean step