### PR TITLE
Update documentation configuration and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,10 +24,10 @@ backup/
 *.ttf
 *.png
 *.css
-docs/html/
-docs/cov/
+
 docs/dev/build/
 docs/dev/source/
+docs/dev/coverage/
 
 !requirements.txt
 !files/**

--- a/docs/dev/conf.py
+++ b/docs/dev/conf.py
@@ -4,13 +4,21 @@ Configuration file for the Sphinx documentation builder.
 
 import os
 import sys
+import tomllib
+from typing import Any
 
 sys.path.insert(0, os.path.abspath("../../"))
 
+with open("../../pyproject.toml", mode="rb") as toml_file:
+    toml_data: dict[str, Any] = tomllib.load(toml_file)
+    project_data: dict[str, Any] = toml_data.get("project")
+
 # -- Project information -----------------------------------------------------
-project = "Mahjong score management tool"
-copyright = "2026, togakushi"
+project = "Developer"
 author = "togakushi"
+copyright = f"%Y, {author}"
+version = project_data.get("version", "")
+release = project_data.get("version", "")
 
 # -- General configuration ---------------------------------------------------
 extensions = [
@@ -20,7 +28,6 @@ extensions = [
 ]
 
 templates_path = ["templates"]
-exclude_patterns = []
 
 # -- Options for autodoc ----------------------------------------------------
 autodoc_typehints = "description"
@@ -32,3 +39,8 @@ napoleon_numpy_docstring = True
 
 # -- Options for HTML output -------------------------------------------------
 html_theme = "python_docs_theme"
+html_title = f"{project} Documentation"
+html_last_updated_fmt = "%Y-%m-%d"
+html_split_index = False
+html_show_sphinx = False
+html_show_copyright = False

--- a/docs/dev/templates/layout.html
+++ b/docs/dev/templates/layout.html
@@ -1,7 +1,6 @@
 {% extends "!layout.html" %}
 
 {%- macro relbar() %}
-{# modified from sphinx/themes/basic/layout.html #}
     <div class="related" role="navigation" aria-label="related navigation">
       <h3>{{ _('Navigation') }}</h3>
       <ul>
@@ -43,18 +42,18 @@
 
 {% block footer %}
     <div class="footer">
-    &copy; {% if theme_copyright_url or hasdoc('copyright') -%}
-      <a href="{% if theme_copyright_url %}{{ theme_copyright_url }}{% else %}{{ pathto('copyright') }}{% endif %}">
-    {%- endif -%}
-    {%- trans %}Copyright{% endtrans -%}
-    {%- if theme_copyright_url or hasdoc('copyright') -%}
-    </a>
-    {%- endif %} {{ copyright|e }}.
+    {%- if show_copyright %}
+      {%- if hasdoc("copyright") %}
+        {%- trans path=pathto("copyright"), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
+      {%- else %}
+        {%- trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}
+      {%- endif %}
+    {%- endif %}
+    {%- if release %}
+      {% trans release=release|e %}Release Version: {{ release }}.{% endtrans %}
+    {%- endif %}
     {%- if last_updated %}
       {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
     {%- endif %}
-    {% if theme_issues_url %}
-      {% trans %}<a href="{{ theme_issues_url }}">Found a bug</a>?{% endtrans %}
-    {% endif %}
     </div>
 {% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mahjong-score-management"
-version = "0.13.0"
+version = "0.13.1"
 description = "Mahjong score management tool"
 readme = "README.md"
 license = "MIT"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
-pdoc
+sphinx
+python-docs-theme
 pytest
 pytest-cov
 mypy


### PR DESCRIPTION
This pull request updates the developer documentation configuration to automatically extract project metadata from `pyproject.toml`, improves the documentation theme and footer, and updates dependencies. The main focus is on making the documentation more dynamic and consistent with project metadata.

**Documentation configuration improvements:**

* The Sphinx `conf.py` now reads project metadata such as `version` directly from `pyproject.toml` using `tomllib`, ensuring the documentation always reflects the current project version and metadata. (`docs/dev/conf.py`)
* The HTML documentation output is enhanced with a custom title, last updated date, and cleaner appearance by hiding Sphinx and copyright notices. (`docs/dev/conf.py`)

**Footer and template enhancements:**

* The documentation footer now conditionally displays copyright, release version, and last updated date, all dynamically populated from project metadata. (`docs/dev/templates/layout.html`)

**Dependency updates:**

* The documentation dependencies switch from `pdoc` to `sphinx` and `python-docs-theme` for generating and theming the docs. (`tests/requirements.txt`)

**Project metadata update:**

* The project version is bumped from `0.13.0` to `0.13.1` in `pyproject.toml`.- Refactor Sphinx configuration to load project version from pyproject.toml
- Adjust HTML template for improved copyright and version display
- Update .gitignore to exclude specific documentation build directories
- Bump project version to 0.13.1 in pyproject.toml
- Modify test requirements to include Sphinx and python-docs-theme