### PR TITLE
Improve help message formatting in app.py and dbtools.py for better r…

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,23 +6,32 @@ help:
     usage: app.py [-h] ...
 
     options:
-        -h, --help            show this help message and exit
-        -c, --config CONFIG   設定ファイル(default: config.ini)
-        -s, --service {slack,discord,standard_io,std,web,flask}
-                              連携先サービス
+        -h, --help
+            show this help message and exit
+        -c CONFIG, --config=CONFIG
+            設定ファイル(default: config.ini)
+        -s SERVICE, --service=SERVICE
+            連携先サービス(slack, discord, standard_io, std, web, flask)
 
     logging options:
-        -d, --debug           デバッグレベル(-d, -dd)
-        -v, --verbose         動作ログ出力レベル(-v, -vv, -vvv)
-        --moderate            ログレベルがエラー以下のもを非表示
-        --notime              ログフォーマットから日時を削除
+        -d, --debug
+            デバッグレベル(-d, -dd)
+        -v, --verbose
+            動作ログ出力レベル(-v, -vv, -vvv)
+        --moderate
+            ログレベルがエラー以下のもを非表示
+        --notime
+            ログフォーマットから日時を削除
 
     Only allowed when --service=standard_io:
-        --text TEXT           input text strings
+        --text TEXT
+            input text strings
 
     Only allowed when --service=web:
-        --host HOST           listen  address(default: 127.0.0.1)
-        --port PORT           bind port(default: 8000)
+        --host HOST
+            listen  address(default: 127.0.0.1)
+        --port PORT
+            bind port(default: 8000)
 """
 
 import sys

--- a/dbtools.py
+++ b/dbtools.py
@@ -6,28 +6,38 @@ help:
     usage: dbtools.py [-h] ...
 
     options:
-        -h, --help            show this help message and exit
-        -c CONFIG, --config CONFIG
-                              設定ファイル(default: config.ini)
-        --service {slack,standard_io,std,web,flask}
-                              連携先サービス
+        -h, --help
+            show this help message and exit
+        -c CONFIG, --config=CONFIG
+            設定ファイル(default: config.ini)
+        -s SERVICE, --service=SERVICE
+            連携先サービス(slack, standard_io, std,web, flask)
 
     logging options:
-        -d, --debug           デバッグレベル(-d, -dd)
-        -v, --verbose         動作ログ出力レベル(-v, -vv, -vvv)
-        --moderate            ログレベルがエラー以下のもを非表示
-        --notime              ログフォーマットから日時を削除
+        -d, --debug
+            デバッグレベル(-d, -dd)
+        -v, --verbose
+            動作ログ出力レベル(-v, -vv, -vvv)
+        --moderate
+            ログレベルがエラー以下のもを非表示
+        --notime
+            ログフォーマットから日時を削除
 
     Required options(amutually exclusive):
-        --compar              データ突合
-        --unification [UNIFICATION]
-                              ファイルの内容に従って記録済みのメンバー名を修正する(default: rename.ini)
-        --recalculation       ポイント再計算
-        --export [PREFIX]     メンバー設定情報をエクスポート(default prefix: export)
-        --import [PREFIX]     メンバー設定情報をインポート(default prefix: export)
-        --vacuum              database vacuum
-        --gen-test-data [count]
-                              テスト用サンプルデータ生成(count=生成回数, default: 1)
+        --compar
+            データ突合
+        --unification=UNIFICATION
+            ファイルの内容に従って記録済みのメンバー名を修正する(default: rename.ini)
+        --recalculation
+            ポイント再計算
+        --export=PREFIX
+            メンバー設定情報をエクスポート(default prefix: export)
+        --import=PREFIX
+            メンバー設定情報をインポート(default prefix: export)
+        --vacuum
+            database vacuum
+        --gen-test-data=count
+            テスト用サンプルデータ生成(count=生成回数, default: 1)
 """
 
 import libs.global_value as g


### PR DESCRIPTION
This pull request updates the help message formatting and argument descriptions in both `app.py` and `dbtools.py` to improve readability and consistency. The changes mainly affect how command-line options are displayed, making them clearer for users.

Improvements to help message formatting and option descriptions:

* Reformatted the help message in `app.py` to use a more readable style with clearer separation between option flags and their descriptions, and clarified the accepted values for the `--service` option.
* Updated the help message in `dbtools.py` to match the new formatting style, added missing short options, standardized the use of `--option=VALUE` notation, and improved the clarity of descriptions for required and optional arguments.…eadability