### PR TITLE
Fix path in documentation generation workflow for user source

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
           uv run sphinx-build -M html ./temp_docs/source/ ./temp_docs/dev/build --conf-dir ./docs/dev/
           cp -r ./temp_docs/dev/build/html ./temp_docs/html/dev
 
-          uv run sphinx-build -M html ./temp_docs/source/ ./temp_docs/user/build --conf-dir ./docs/user/
+          uv run sphinx-build -M html ./docs/user/source/ ./temp_docs/user/build --conf-dir ./docs/user/
           cp -r ./temp_docs/user/build/html ./temp_docs/html/user
 
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
This pull request makes a small but important fix to the documentation build workflow. The change ensures that the Sphinx build for the user documentation uses the correct source directory, which should help prevent build errors.

- Updated the Sphinx build command in `.github/workflows/docs.yml` to use `./docs/user/source/` as the source directory for user documentation instead of `./temp_docs/source/`.