### PR TITLE
Update README to include direct links for Slack and Discord setup ins…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,12 @@
 
 ### セットアップ方法
 
-* [Slack](docs/setting/for_slack/README.md)
-
-* [Discord](docs/setting/for_discord/README.md)
+* [Slack](https://togakushi.github.io/mahjong-score-management/user/setting/for_slack/index.html)
+* [Discord](https://togakushi.github.io/mahjong-score-management/user/setting/for_discord/index.html)
 
 ## 主な機能
 
-### スコア記録
+### スコア記録（ [詳細](https://togakushi.github.io/mahjong-score-management/user/functions/input/score_record.html) ）
 
 以下のフォーマットに一致した投稿をデータベースに取り込む。
 
@@ -28,22 +27,22 @@
 
 成績管理をするプレイヤーを登録し、スコアを蓄積する。
 
-### 成績サマリ出力機能
+### 成績サマリ出力機能（ [詳細](https://togakushi.github.io/mahjong-score-management/user/functions/output/results/index.html) ）
 
 記録されているスコアを集計し、一覧で出力する。
 
-### グラフ生成機能
+### グラフ生成機能（ [詳細](https://togakushi.github.io/mahjong-score-management/user/functions/output/graph/index.html) ）
 
 記録されているスコアを集計し、グラフで出力する。
 
-### ランキング出力機能
+### ランキング出力機能（ [詳細](https://togakushi.github.io/mahjong-score-management/user/functions/output/ranking/index.html) ）
 
 記録されているスコアを集計し、ランキング形式で出力する。
 
-### レポート出力機能
+### レポート出力機能（ [詳細](https://togakushi.github.io/mahjong-score-management/user/functions/output/report/index.html) ）
 
 月間成績上位者、個人成績一覧、ゲーム統計情報を表形式で出力する。
 
-### スラッシュコマンド
+### スラッシュコマンド（ [詳細](https://togakushi.github.io/mahjong-score-management/user/functions/appendix/command.html) ）
 
 出力結果をボットから直接DMで受け取る。


### PR DESCRIPTION
This pull request updates the `README.md` to improve user guidance by replacing local documentation links with direct links to the published GitHub Pages documentation. This makes it easier for users to access detailed setup and feature descriptions.

Documentation improvements:

* Updated setup links for Slack and Discord to point to the corresponding pages on GitHub Pages instead of local markdown files.
* Updated all feature section headers to include direct links to their detailed documentation on GitHub Pages, improving navigation and clarity for users.…tructions