### PR TITLE
Refactor graph output section to group images under compound directiv…

### DIFF
--- a/docs/user/source/functions/output/graph/index.rst
+++ b/docs/user/source/functions/output/graph/index.rst
@@ -102,23 +102,27 @@
 
 .. admonition:: 全体成績(折れ線グラフ)
 
-   .. image:: point_line_ggplot.png
-      :scale: 30%
-      :alt: 出力サンプル(ggplot)
+   .. compound::
 
-   .. image:: point_line_dark.png
-      :scale: 30%
-      :alt: 出力サンプル(dark_background)
+      .. image:: point_line_ggplot.png
+         :scale: 30%
+         :alt: 出力サンプル(ggplot)
+
+      .. image:: point_line_dark.png
+         :scale: 30%
+         :alt: 出力サンプル(dark_background)
 
 .. admonition:: 全体成績(棒グラフ)
 
-   .. image:: point_bar_ggplot.png
-      :scale: 30%
-      :alt: 出力サンプル(ggplot)
+   .. compound::
 
-   .. image:: point_bar_dark.png
-      :scale: 30%
-      :alt: 出力サンプル(dark_background)
+      .. image:: point_bar_ggplot.png
+         :scale: 30%
+         :alt: 出力サンプル(ggplot)
+
+      .. image:: point_bar_dark.png
+         :scale: 30%
+         :alt: 出力サンプル(dark_background)
 
 
 個人成績グラフ詳細


### PR DESCRIPTION
This pull request makes minor documentation improvements by updating the graph output section to improve the structure and formatting of admonitions.

- Documentation formatting:
  * Wrapped the images for the "全体成績(折れ線グラフ)" and "全体成績(棒グラフ)" sections in a `.. compound::` directive in `docs/user/source/functions/output/graph/index.rst` for better formatting and clarity. [[1]](diffhunk://#diff-720d57ed91ee9730730b1e2075cb0f6e4f854e07d78f7f8f289b9ac2792a2175R105-R106) [[2]](diffhunk://#diff-720d57ed91ee9730730b1e2075cb0f6e4f854e07d78f7f8f289b9ac2792a2175R117-R118)…es for better organization