### PR TITLE
Update header title formatting in AdapterAPI to include print_title

### DIFF
--- a/integrations/slack/api.py
+++ b/integrations/slack/api.py
@@ -78,7 +78,7 @@ class AdapterAPI(APIInterface):
         header_text = ""
         if m.post.headline:
             header_data, header_option = m.post.headline
-            header_title = header_option.title
+            header_title = f"{header_option.print_title}\n"
             if isinstance(header_data, str):
                 header_text = header_data
         if not m.post.message:  # メッセージなし


### PR DESCRIPTION
This pull request makes a small update to the way the post header is constructed in the Slack integration. The change ensures that the `print_title` attribute from `header_option` is used and adds a newline character for improved formatting.