### PR TITLE
Remove hidden columns from stats DataFrame based on draw split rule

### DIFF
--- a/libs/commands/results/detail.py
+++ b/libs/commands/results/detail.py
@@ -244,6 +244,22 @@ def comparison(m: "MessageParserProtocol") -> None:
         stats_df.index = list(mapping_dict.values())
 
     # 非表示項目
+    if g.cfg.rule.get_draw_split(g.params.rule_version):
+        stats_df.drop(
+            columns=[
+                "rank1_rate-count",
+                "rank2_rate-count",
+                "rank3_rate-count",
+                "rank4_rate-count",
+                "top2_balance",
+                "lose2_balance",
+                "rank1_balance",
+                "rank2_balance",
+                "rank3_balance",
+                "rank4_balance",
+            ],
+            inplace=True,
+        )
     stats_df.drop(columns=formatter.dropitems_list(stats_df.columns.to_list()), inplace=True)
 
     # 出力


### PR DESCRIPTION
This pull request introduces a conditional column removal in the `comparison` function to improve data presentation based on the rule version. Specifically, certain statistical columns are now dropped from the DataFrame if a specific draw split rule is enabled.

Conditional DataFrame column removal based on rule version:

* In `libs/commands/results/detail.py`, the `comparison` function now checks if the draw split rule is active (via `g.cfg.rule.get_draw_split(g.params.rule_version)`) and, if so, drops a set of statistical columns (such as `"rank1_rate-count"`, `"top2_balance"`, etc.) from the DataFrame to streamline the output.