### PR TITLE
Refactor rating calculation and enhance visual consistency

### DIFF
--- a/integrations/web/events/create_bp/graph.py
+++ b/integrations/web/events/create_bp/graph.py
@@ -64,10 +64,16 @@ def graph_bp(adapter: "ServiceAdapter") -> Blueprint:
                     ("", "ゲーム数"),
                     ("1位", "獲得数"),
                     ("1位", "獲得率"),
+                    ("1.5位", "獲得数"),
+                    ("1.5位", "獲得率"),
                     ("2位", "獲得数"),
                     ("2位", "獲得率"),
+                    ("2.5位", "獲得数"),
+                    ("2.5位", "獲得率"),
                     ("3位", "獲得数"),
                     ("3位", "獲得率"),
+                    ("3.5位", "獲得数"),
+                    ("3.5位", "獲得率"),
                     ("4位", "獲得数"),
                     ("4位", "獲得率"),
                     ("", "平均順位"),
@@ -76,6 +82,9 @@ def graph_bp(adapter: "ServiceAdapter") -> Blueprint:
                     ("", "通算ポイント"),
                 ]
                 data.columns = pd.MultiIndex.from_tuples(multi)
+                for rank in ["1.5位", "2.5位", "3.5位"]:
+                    if not data[(rank, "獲得数")].sum():
+                        data.drop(columns=[(rank, "獲得数"), (rank, "獲得率")], inplace=True)
                 message += f"<h2>{options.title}</h2>\n"
                 message += adapter.functions.to_styled_html(data, padding, show_index)
 

--- a/libs/commands/graph/personal.py
+++ b/libs/commands/graph/personal.py
@@ -199,10 +199,16 @@ def statistics_plot(m: "MessageParserProtocol") -> None:
         "ゲーム数": rank_df.count().astype("int"),
         "1位": rank_df[rank_df == 1].count().astype("int"),
         "1位(%)": ((rank_df[rank_df == 1].count()) / rank_df.count()),
+        "1.5位": rank_df[rank_df == 1.5].count().astype("int"),
+        "1.5位(%)": ((rank_df[rank_df == 1.5].count()) / rank_df.count()),
         "2位": rank_df[rank_df == 2].count().astype("int"),
         "2位(%)": ((rank_df[rank_df == 2].count()) / rank_df.count()),
+        "2.5位": rank_df[rank_df == 2.5].count().astype("int"),
+        "2.5位(%)": ((rank_df[rank_df == 2.5].count()) / rank_df.count()),
         "3位": rank_df[rank_df == 3].count().astype("int"),
         "3位(%)": ((rank_df[rank_df == 3].count()) / rank_df.count()),
+        "3.5位": rank_df[rank_df == 3.5].count().astype("int"),
+        "3.5位(%)": ((rank_df[rank_df == 3.5].count()) / rank_df.count()),
         "4位": rank_df[rank_df == 4].count().astype("int"),
         "4位(%)": ((rank_df[rank_df == 4].count()) / rank_df.count()),
         "平均順位": rank_df.mean().round(2),
@@ -217,10 +223,16 @@ def statistics_plot(m: "MessageParserProtocol") -> None:
             "ゲーム数": int(count_df["ゲーム数"].sum()),
             "1位": int(count_df["1位"].sum()),
             "1位(%)": float(count_df["1位"].sum() / count_df["ゲーム数"].sum()),
+            "1.5位": int(count_df["1.5位"].sum()),
+            "1.5位(%)": float(count_df["1.5位"].sum() / count_df["ゲーム数"].sum()),
             "2位": int(count_df["2位"].sum()),
             "2位(%)": float(count_df["2位"].sum() / count_df["ゲーム数"].sum()),
+            "2.5位": int(count_df["2.5位"].sum()),
+            "2.5位(%)": float(count_df["2.5位"].sum() / count_df["ゲーム数"].sum()),
             "3位": int(count_df["3位"].sum()),
             "3位(%)": float(count_df["3位"].sum() / count_df["ゲーム数"].sum()),
+            "3.5位": int(count_df["3.5位"].sum()),
+            "3.5位(%)": float(count_df["3.5位"].sum() / count_df["ゲーム数"].sum()),
             "4位": int(count_df["4位"].sum()),
             "4位(%)": float(count_df["4位"].sum() / count_df["ゲーム数"].sum()),
             "平均順位": float(round(player_df["rank"].mean(), 2)),
@@ -232,9 +244,16 @@ def statistics_plot(m: "MessageParserProtocol") -> None:
     rank_table = pd.DataFrame()
     rank_table["ゲーム数"] = count_df["ゲーム数"].astype("int")
     rank_table["1位"] = count_df.apply(lambda row: f"{row['1位(%)']:.2%} ({row['1位']:.0f})", axis=1)
+    if count_df["1.5位"].drop(index=["全区間"]).sum():
+        rank_table["1.5位"] = count_df.apply(lambda row: f"{row['1.5位(%)']:.2%} ({row['1.5位']:.0f})", axis=1)
     rank_table["2位"] = count_df.apply(lambda row: f"{row['2位(%)']:.2%} ({row['2位']:.0f})", axis=1)
+    if count_df["2.5位"].drop(index=["全区間"]).sum():
+        rank_table["2.5位"] = count_df.apply(lambda row: f"{row['2.5位(%)']:.2%} ({row['2.5位']:.0f})", axis=1)
     rank_table["3位"] = count_df.apply(lambda row: f"{row['3位(%)']:.2%} ({row['3位']:.0f})", axis=1)
-    rank_table["4位"] = count_df.apply(lambda row: f"{row['4位(%)']:.2%} ({row['4位']:.0f})", axis=1)
+    if count_df["3.5位"].drop(index=["全区間"]).sum():
+        rank_table["3.5位"] = count_df.apply(lambda row: f"{row['3.5位(%)']:.2%} ({row['3.5位']:.0f})", axis=1)
+    if g.params.mode == 4:
+        rank_table["4位"] = count_df.apply(lambda row: f"{row['4位(%)']:.2%} ({row['4位']:.0f})", axis=1)
     rank_table["平均順位"] = count_df.apply(lambda row: f"{row['平均順位']:.2f}", axis=1)
 
     m.set_headline(message.header(game_info, m), StyleOptions(title=f"『{player}』の成績"))
@@ -245,7 +264,7 @@ def statistics_plot(m: "MessageParserProtocol") -> None:
         case "plotly":
             m.set_message(count_df, StyleOptions(title="順位/ポイント情報", show_index=True))
             m.set_message(plotly_line("通算ポイント推移", point_df), StyleOptions(title="通算ポイント"))
-            m.set_message(plotly_bar("順位分布", count_df.drop(index=["全区間"])), StyleOptions(title="順位分布"))
+            m.set_message(plotly_bar("順位分布", count_df), StyleOptions(title="順位分布"))
             m.set_message(stats_df, StyleOptions(title="素点情報", show_index=True))
             m.set_message(plotly_box("素点分布", rpoint_df), StyleOptions(title="素点分布"))
         case "matplotlib":
@@ -423,8 +442,11 @@ def subplot_rank(df: pd.DataFrame, ax: Axes, total_index: str) -> None:
 
     """
     df["1位(%)"] = df["1位(%)"] * 100
+    df["1.5位(%)"] = df["1.5位(%)"] * 100
     df["2位(%)"] = df["2位(%)"] * 100
+    df["2.5位(%)"] = df["2.5位(%)"] * 100
     df["3位(%)"] = df["3位(%)"] * 100
+    df["3.5位(%)"] = df["3.5位(%)"] * 100
     df["4位(%)"] = df["4位(%)"] * 100
 
     ax_rank_avg = ax.twinx()
@@ -442,7 +464,14 @@ def subplot_rank(df: pd.DataFrame, ax: Axes, total_index: str) -> None:
     ax_rank_avg.invert_yaxis()
     ax_rank_avg.axhline(y=(1 + g.params.mode) / 2, linewidth=0.5, ls="dashed", color="grey")
 
-    filter_items = ["1位(%)", "2位(%)", "3位(%)", "4位(%)"][: g.params.mode]
+    filter_items = ["1位(%)", "1.5位(%)", "2位(%)", "2.5位(%)", "3位(%)", "3.5位(%)", "4位(%)"]
+    if g.params.mode == 3:
+        filter_items.remove("3.5位(%)")
+        filter_items.remove("4位(%)")
+    for x in ("1.5位(%)", "2.5位(%)", "3.5位(%)"):
+        if not df[x].drop(index=["全区間"]).sum() and x in filter_items:
+            filter_items.remove(x)
+
     df.filter(items=filter_items).drop(index=total_index).plot(
         ax=ax,
         kind="bar",
@@ -453,6 +482,7 @@ def subplot_rank(df: pd.DataFrame, ax: Axes, total_index: str) -> None:
         rot=90,
         ylim=[-5, 105],
     )
+
     h1, l1 = ax.get_legend_handles_labels()
     h2, l2 = ax_rank_avg.get_legend_handles_labels()
     ax.legend(
@@ -717,12 +747,23 @@ def plotly_bar(title_text: str, df: pd.DataFrame) -> "Path":
     """
     save_file = textutil.save_file_path("rank.html")
 
+    if len(df.index) <= 2:
+        df.drop(index=["全区間"], inplace=True)
+
     fig = make_subplots(specs=[[{"secondary_y": True}]])
+
     # 獲得率
     fig.add_trace(go.Bar(name="4位率", x=df.index, y=df["4位(%)"] * 100), secondary_y=False)
+    if df["3.5位"].sum():
+        fig.add_trace(go.Bar(name="3.5位率", x=df.index, y=df["3.5位(%)"] * 100), secondary_y=False)
     fig.add_trace(go.Bar(name="3位率", x=df.index, y=df["3位(%)"] * 100), secondary_y=False)
+    if df["2.5位"].sum():
+        fig.add_trace(go.Bar(name="2.5位率", x=df.index, y=df["2.5位(%)"] * 100), secondary_y=False)
     fig.add_trace(go.Bar(name="2位率", x=df.index, y=df["2位(%)"] * 100), secondary_y=False)
+    if df["1.5位"].sum():
+        fig.add_trace(go.Bar(name="1.5位率", x=df.index, y=df["1.5位(%)"] * 100), secondary_y=False)
     fig.add_trace(go.Bar(name="1位率", x=df.index, y=df["1位(%)"] * 100), secondary_y=False)
+
     # 平均順位
     fig.add_trace(
         go.Scatter(

--- a/libs/commands/graph/personal.py
+++ b/libs/commands/graph/personal.py
@@ -372,6 +372,15 @@ def subplot_table(df: pd.DataFrame, ax: Axes) -> None:
         loc="center",
     )
     table.auto_set_font_size(False)
+
+    # セル背景色とFigure背景色を合わせる
+    ax_fc = ax.figure.get_facecolor()  # Figure背景色
+    ax_tc = ax.title.get_color()  # タイトル文字色
+    for cell in table.get_celld().values():
+        cell.set_facecolor(ax_fc)  # セル背景色
+        cell.set_edgecolor(ax_tc)  # 罫線
+        cell.get_text().set_color(ax_tc)  # セル文字色
+
     ax.axis("off")
 
 

--- a/libs/commands/ranking/rating.py
+++ b/libs/commands/ranking/rating.py
@@ -33,7 +33,7 @@ def aggregation(m: "MessageParserProtocol") -> None:
     title: str = "レーティング"
     add_text: str = ""
 
-    if g.cfg.rule.get_draw_split(g.params.rule_version) or g.params.mode == 3 or g.params.target_mode == 3:  # todo: 未実装
+    if g.params.mode == 3 or g.params.target_mode == 3:  # todo: 未実装
         m.set_headline(message.random_reply(m, "not_implemented"), StyleOptions(title=title))
         m.status.result = False
         return

--- a/libs/domain/aggregate.py
+++ b/libs/domain/aggregate.py
@@ -77,7 +77,7 @@ def calculation_rating() -> pd.DataFrame:
 
         for i, player in enumerate(player_list):
             rating = float(rating_list[i])
-            rank = f"{rank_list[i]:.1f}"
+            rank = "{:.1f}".format(float(str(rank_list[i])))
 
             correction_value: float = (rating_avg - rating) / 40
             if df_ratings[player].count() >= 400:

--- a/libs/domain/aggregate.py
+++ b/libs/domain/aggregate.py
@@ -141,7 +141,6 @@ def grade_promotion_check(grade_level: int, point: int, rank: int) -> tuple[int,
     return (new_point, grade_level)
 
 
-# レポート
 def matrix_table() -> pd.DataFrame:
     """
     対局対戦マトリックス表の作成

--- a/libs/domain/aggregate.py
+++ b/libs/domain/aggregate.py
@@ -59,7 +59,7 @@ def calculation_rating() -> pd.DataFrame:
     last_ratings: dict[str, float] = {}  # 最終値格納用
 
     # 獲得スコア
-    score_mapping = {"1": 30.0, "2": 10.0, "3": -10.0, "4": -30.0}
+    score_mapping = {"1.0": 30.0, "1.5": 20.0, "2.0": 10.0, "2.5": 0.0, "3.0": -10.0, "3.5": -20.0, "4.0": -30.0}
 
     for x in df_results.itertuples():
         player_list = (str(x.p1_name), str(x.p2_name), str(x.p3_name), str(x.p4_name))
@@ -77,7 +77,7 @@ def calculation_rating() -> pd.DataFrame:
 
         for i, player in enumerate(player_list):
             rating = float(rating_list[i])
-            rank = str(rank_list[i])
+            rank = f"{rank_list[i]:.1f}"
 
             correction_value: float = (rating_avg - rating) / 40
             if df_ratings[player].count() >= 400:
@@ -85,7 +85,7 @@ def calculation_rating() -> pd.DataFrame:
             else:
                 match_correction = 1 - df_ratings[player].count() * 0.002
 
-            new_rating = rating + match_correction * (score_mapping[rank] + correction_value)
+            new_rating = rating + match_correction * (score_mapping.get(rank, 0.0) + correction_value)
 
             last_ratings[player] = new_rating
             df_ratings.loc[x.Index, player] = new_rating

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mahjong-score-management"
-version = "0.14.2"
+version = "0.14.3"
 description = "Mahjong score management tool"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mahjong-score-management"
-version = "0.14.3"
+version = "0.14.4"
 description = "Mahjong score management tool"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
This pull request adds support for handling fractional ranks (such as 1.5位, 2.5位, 3.5位) throughout the ranking and statistics features. It updates the data processing, visualization, and rating calculation logic to include these new ranks, ensuring that all relevant tables, plots, and calculations reflect the additional rank possibilities.

Key changes include:

**Support for Fractional Ranks in Data and Visualizations:**

- Added columns and calculations for 1.5位, 2.5位, and 3.5位 (both counts and rates) in the statistics and summary tables in `libs/commands/graph/personal.py` and `integrations/web/events/create_bp/graph.py`. Conditional logic ensures these columns are only shown if relevant data exists. [[1]](diffhunk://#diff-cb9f46caefb61462e42dc7ffa34359c1341c5a5b4b4264db6ab8c748d812bd56R202-R211) [[2]](diffhunk://#diff-cb9f46caefb61462e42dc7ffa34359c1341c5a5b4b4264db6ab8c748d812bd56R226-R235) [[3]](diffhunk://#diff-cb9f46caefb61462e42dc7ffa34359c1341c5a5b4b4264db6ab8c748d812bd56R247-R255) [[4]](diffhunk://#diff-cb9f46caefb61462e42dc7ffa34359c1341c5a5b4b4264db6ab8c748d812bd56L248-R267) [[5]](diffhunk://#diff-7aa38bd2c1cbc4e0c437eafe1fe2c67f7441b5db1a53521d8c17aef72c95f9c4R67-R76) [[6]](diffhunk://#diff-7aa38bd2c1cbc4e0c437eafe1fe2c67f7441b5db1a53521d8c17aef72c95f9c4R85-R87)
- Updated plotting functions to include the new fractional ranks in both matplotlib and plotly visualizations, with logic to hide unused fractional rank columns and ensure correct color and legend handling. [[1]](diffhunk://#diff-cb9f46caefb61462e42dc7ffa34359c1341c5a5b4b4264db6ab8c748d812bd56R445-R449) [[2]](diffhunk://#diff-cb9f46caefb61462e42dc7ffa34359c1341c5a5b4b4264db6ab8c748d812bd56L436-R474) [[3]](diffhunk://#diff-cb9f46caefb61462e42dc7ffa34359c1341c5a5b4b4264db6ab8c748d812bd56R485) [[4]](diffhunk://#diff-cb9f46caefb61462e42dc7ffa34359c1341c5a5b4b4264db6ab8c748d812bd56R750-R766)

**Rating Calculation Adjustments:**

- Expanded the `score_mapping` in `libs/domain/aggregate.py` to assign point values for fractional ranks, and updated the logic to correctly match floating-point rank strings. [[1]](diffhunk://#diff-4bb05e28b69008ed9c1bbdfa89620303941e85f57de7535fc9a34f35771c4e60L62-R62) [[2]](diffhunk://#diff-4bb05e28b69008ed9c1bbdfa89620303941e85f57de7535fc9a34f35771c4e60L80-R88)

**UI/UX Improvements:**

- Improved table and plot appearance by synchronizing cell background and text colors with the figure style in matplotlib tables.

**Other Minor Changes:**

- Bumped the project version to 0.14.4 in `pyproject.toml`.
- Cleaned up a redundant comment and simplified a rule check in the rating aggregation logic. [[1]](diffhunk://#diff-4bb05e28b69008ed9c1bbdfa89620303941e85f57de7535fc9a34f35771c4e60L144) [[2]](diffhunk://#diff-d73d0a7e72076fc61271e89b75bfc820a564285825bf8133a2d20a64b326cf32L36-R36)