### PR TITLE
Enhance data processing with playtime formatting and remarks cleanup

### DIFF
--- a/files/queries/summary/details2.sql
+++ b/files/queries/summary/details2.sql
@@ -10,7 +10,6 @@ select
     p1_rank,
     --[individual] p1_point,
     --[team] t1_point as p1_point,
-    --[individual] p1_remarks,
     p1_remarks,
     -- 南家
     --[individual] --[unregistered_replace] case when p2_guest = 0 then p2_name else :guest_name end as p2_name, -- ゲスト有効
@@ -20,7 +19,6 @@ select
     p2_rank,
     --[individual] p2_point,
     --[team] t2_point as p2_point,
-    --[individual] p2_remarks,
     p2_remarks,
     -- 西家
     --[individual] --[unregistered_replace] case when p3_guest = 0 then p3_name else :guest_name end as p3_name, -- ゲスト有効
@@ -30,7 +28,6 @@ select
     p3_rank,
     --[individual] p3_point,
     --[team] t3_point as p3_point,
-    --[individual] p3_remarks,
     p3_remarks,
     -- 北家
     --[individual] --[unregistered_replace] case when p4_guest = 0 then p4_name else :guest_name end as p4_name, -- ゲスト有効
@@ -40,8 +37,7 @@ select
     p4_rank,
     --[individual] p4_point,
     --[team] t4_point as p4_point,
-    --[individual] p4_remarks,
-    p4_remarks as p4_remarks,
+    p4_remarks,
     game_info.guest_count,
     game_info.same_team
 from

--- a/libs/utils/converter.py
+++ b/libs/utils/converter.py
@@ -237,12 +237,12 @@ def df_to_results_details(df: pd.DataFrame, options: StyleOptions, limit: int = 
         dict[str, str]: 整形テキスト
 
     """
+    df = formatter.adjusting_values(df)
     df = formatter.df_rename(df, options)
 
     data_list: list[str] = []
     game_results: dict[str, dict[str, Any]] = {}
 
-    # fixme: UserWarning: DataFrame columns are not unique, some columns will be omitted.
     for x in df.to_dict(orient="index").values():
         game_results[x["日時"]] = {"備考": x["備考"]}
         for seat in ("東家", "南家", "西家", "北家"):
@@ -250,9 +250,9 @@ def df_to_results_details(df: pd.DataFrame, options: StyleOptions, limit: int = 
                 {
                     seat: [
                         x[f"{seat} 名前"],
-                        f"{(x[f'{seat} 素点'])}点".replace("-", "▲"),
-                        f"{(x[f'{seat} 順位'])}位",
-                        f"({float(x[f'{seat} ポイント']):+.1f}pt)".replace("-", "▲"),
+                        x[f"{seat} 素点"],
+                        x[f"{seat} 順位"],
+                        x[f"{seat} ポイント"],
                         x[f"{seat} メモ"],
                     ]
                 }
@@ -285,6 +285,7 @@ def df_to_results_simple(df: pd.DataFrame, options: StyleOptions, limit: int = 2
         dict[str, str]: 整形テキスト
 
     """
+    df = formatter.adjusting_values(df)
     df = formatter.df_rename(df, options)
 
     data_list: list[str] = []
@@ -292,10 +293,9 @@ def df_to_results_simple(df: pd.DataFrame, options: StyleOptions, limit: int = 2
         vs_guest = ""
         if x["備考"] != "":
             vs_guest = f"({g.cfg.setting.guest_mark}) "
-
-        ret = f"　{vs_guest}{str(x['日時']).replace('-', '/')}  "
-        ret += f"{x['座席']}\t{x['順位']}位\t{x['素点']:8d}点\t{x['獲得ポイント']:7.1f}pt\t{x['メモ']}".replace("-", "▲")
-        data_list.append(ret)
+        data_list.append(
+            f"　{vs_guest}{x['日時']}\t{x['座席']}\t{x['順位']}\t{x['素点']}\t{x['獲得ポイント']}\t{x['メモ']}",
+        )
 
     return {str(idx): x for idx, x in enumerate(formatter.group_strings(data_list, limit))}
 
@@ -528,16 +528,10 @@ def df_to_remarks(df: pd.DataFrame, options: StyleOptions) -> dict[str, str]:
         dict[str, str]: 整形テキスト
 
     """
+    df = formatter.adjusting_values(df)
     df = formatter.df_rename(df, options)
 
     key_name = "名前" if g.params.individual else "チーム"
-    for col in df.columns:
-        match col:
-            case "日時":
-                df["日時"] = df["日時"].map(lambda x: str(x).replace("-", "/"))
-            case "ポイント":
-                df["ポイント"] = df["ポイント"].map(lambda x: f"{x}pt".replace("-", "▲"))
-
     if "日時" in df.columns:
         if "ポイント" in df.columns:
             df["表示"] = df.apply(lambda x: f"{x['日時']} {x['ポイント']} {x['内容']} （{x[key_name]}）", axis=1)
@@ -547,7 +541,7 @@ def df_to_remarks(df: pd.DataFrame, options: StyleOptions) -> dict[str, str]:
             df["表示"] = df.apply(lambda x: f"{x['日時']} {x['内容']} （{x[key_name]}）", axis=1)
     elif "回数" in df.columns:
         if "ポイント" in df.columns:
-            df["表示"] = df.apply(lambda x: f"{x['内容']}： {x['回数']} 回 ({x['ポイント合計']:.1f}pt)".replace("-", "▲"), axis=1)
+            df["表示"] = df.apply(lambda x: f"{x['内容']}： {x['回数']} 回 ({x['ポイント合計']})", axis=1)
         elif "和了役" in df.columns:
             df["表示"] = df.apply(lambda x: f"{x['和了役']}： {x['回数']} 回", axis=1)
         else:

--- a/libs/utils/formatter.py
+++ b/libs/utils/formatter.py
@@ -606,7 +606,9 @@ def adjusting_values(df: pd.DataFrame, compact: bool = False) -> pd.DataFrame:
                 df[column_name] = df[column_name].map(lambda v: f"{float(v):.2f}")
                 if compact:
                     df.rename(columns={column_name: "平均\n順位"}, inplace=True)
-            case x if x == "point" or x.endswith("_point"):
+            case "playtime":
+                df[column_name] = df[column_name].map(lambda v: str(v).replace("-", "/"))
+            case x if x == "point" or x.endswith(("_point", "_total")):
                 df[column_name] = df[column_name].map(lambda v: str(v) if str(v).endswith("pt") else f"{float(v):+.1f}pt".replace("-", "▲"))
             case x if x == "rpoint" or x.endswith("_rpoint"):
                 df[column_name] = df[column_name].map(lambda v: f"{float(v):.0f}点".replace("-", "▲"))


### PR DESCRIPTION
This pull request primarily refactors how values are formatted and processed in both SQL queries and Python data conversion utilities. The main goal is to centralize value formatting logic in the `adjusting_values` function, simplify output formatting, and remove redundant or inconsistent value manipulations. This should make the codebase easier to maintain and reduce duplication.

**Centralization and Consistency of Value Formatting:**

* Added calls to `formatter.adjusting_values` at the start of key data conversion functions (`df_to_results_details`, `df_to_results_simple`, and `df_to_remarks`) to ensure all value formatting is handled consistently in one place. [[1]](diffhunk://#diff-057ee2ac5fb9c50aeb703d0425f30a8a05e60e9aede89fa1d691a01c35fa9d25R240-R255) [[2]](diffhunk://#diff-057ee2ac5fb9c50aeb703d0425f30a8a05e60e9aede89fa1d691a01c35fa9d25R288-R298) [[3]](diffhunk://#diff-057ee2ac5fb9c50aeb703d0425f30a8a05e60e9aede89fa1d691a01c35fa9d25R531-L540)
* Enhanced `adjusting_values` to handle additional fields, including formatting `playtime` and supporting new suffixes like `_total` for point columns.

**Simplification and Cleanup of Output Formatting:**

* Simplified output string construction in `df_to_results_details` and `df_to_results_simple` by removing inline formatting (such as adding units or replacing characters) and relying on preformatted values from `adjusting_values`. [[1]](diffhunk://#diff-057ee2ac5fb9c50aeb703d0425f30a8a05e60e9aede89fa1d691a01c35fa9d25R240-R255) [[2]](diffhunk://#diff-057ee2ac5fb9c50aeb703d0425f30a8a05e60e9aede89fa1d691a01c35fa9d25R288-R298)
* Cleaned up and removed column-specific formatting logic from `df_to_remarks`, delegating all formatting to `adjusting_values`.

**SQL Query Adjustments:**

* Updated `details2.sql` to always select the `pX_remarks` columns directly, removing conditional or commented-out selection logic for remarks fields. [[1]](diffhunk://#diff-7b2309216b9f8f33f6f67e430fcda5b95a0eef6c05c55da17843edbefb02d502L13) [[2]](diffhunk://#diff-7b2309216b9f8f33f6f67e430fcda5b95a0eef6c05c55da17843edbefb02d502L23) [[3]](diffhunk://#diff-7b2309216b9f8f33f6f67e430fcda5b95a0eef6c05c55da17843edbefb02d502L33) [[4]](diffhunk://#diff-7b2309216b9f8f33f6f67e430fcda5b95a0eef6c05c55da17843edbefb02d502L43-R40)

**Other Formatting Adjustments:**

* Removed or simplified string replacements (such as replacing "-" with "▲") and formatting for point totals in remarks output, since this is now handled in `adjusting_values`.

Overall, these changes should make the formatting process more robust and easier to update in the future.