### PR TITLE
Refactor merge_dicts and enhance arg_parser for flexibility

### DIFF
--- a/dbtools.py
+++ b/dbtools.py
@@ -28,8 +28,8 @@ help:
             データ突合
         --unification=UNIFICATION
             ファイルの内容に従って記録済みのメンバー名を修正する(default: rename.ini)
-        --recalculation
-            ポイント再計算
+        --recalculation [RULE_VERSION ...]
+            ポイント再計算(引数なし=全ルール, 引数あり=指定ルールのみ)
         --export=PREFIX
             メンバー設定情報をエクスポート(default prefix: export)
         --import=PREFIX

--- a/dbtools.py
+++ b/dbtools.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 
     if g.args.compar:
         comparison.main()
-    if g.args.recalculation:
+    if g.args.recalculation or g.args.recalculation is not None:
         recalculation.main()
     if g.args.unification:
         unification.main()

--- a/docs/user/source/commandline_tool/dbtools.rst
+++ b/docs/user/source/commandline_tool/dbtools.rst
@@ -32,7 +32,6 @@ dbtools.py
 .. option:: -h, --help
 
    :内容: ヘルプ表示
-   :省略時:
    :備考:
 
 .. option:: -c CONFIG, --config=CONFIG
@@ -91,7 +90,6 @@ dbtools.py
 .. option:: --compar
 
    :内容: データ突合
-   :省略時:
    :備考: ``--service`` で指定されている連携先と接続する
 
 .. option:: --unification=UNIFICATION
@@ -108,13 +106,13 @@ dbtools.py
       [rename]
       置き換え後の名前 = 置き換え前の名前, 置き換え前の名前, ...
 
-.. option:: --recalculation
+.. option:: --recalculation=[RULE_VERSION ...]
 
    :内容: ポイント再計算
-   :省略時:
+   :省略時: 全ルールバージョン
    :備考: 記録済みデータの素点からポイントを再計算する
 
-   | DBからスコア情報を取り込み、定義済みの `ルールセット` と一致する `rule_version` であればその `ルールセット` の集計方法で再計算する。
+   | DBからスコア情報を取り込み、引数で指定した `rule_version`  の `ルールセット` で再計算する。
    | 過去のデータを含め、すべてのレコードのポイントを再計算して更新する(変更点がなくても必ずupdateされる)。
 
 .. option:: --export=PREFIX

--- a/libs/bootstrap/configuration.py
+++ b/libs/bootstrap/configuration.py
@@ -153,8 +153,10 @@ def arg_parser() -> Args:
             )
             exclusive.add_argument(
                 "--recalculation",
-                action="store_true",
-                help="ポイント再計算",
+                type=str,
+                nargs="*",
+                metavar="RULE_VERSION",
+                help="ポイント再計算(引数なし=全ルール, 引数あり=指定ルールのみ)",
             )
             exclusive.add_argument(
                 "--export",

--- a/libs/domain/datamodels.py
+++ b/libs/domain/datamodels.py
@@ -50,7 +50,7 @@ class Args:
     # dbtools
     compar: bool
     unification: "Path"
-    recalculation: bool
+    recalculation: list[str]
     export_data: str
     import_data: str
     vacuum: bool

--- a/libs/functions/tools/recalculation.py
+++ b/libs/functions/tools/recalculation.py
@@ -28,7 +28,6 @@ def main() -> None:
 
     with closing(dbutil.connection(g.cfg.setting.database_file)) as cur:
         for rule_version in target_rule:
-            print(rule_version)
             logging.info("%s", vars(g.cfg.rule.data.get(rule_version)))
             rows = cur.execute(
                 """

--- a/libs/functions/tools/recalculation.py
+++ b/libs/functions/tools/recalculation.py
@@ -15,11 +15,21 @@ def main() -> None:
     """ポイント再計算"""
     g.cfg.initialization()
 
+    target_rule: set[str] = set()
+    for x in g.args.recalculation:
+        if chk := g.cfg.rule.keyword_mapping.get(x):
+            target_rule.add(chk)
+        if x in g.cfg.rule.rule_list:
+            target_rule.add(x)
+    if not target_rule:
+        target_rule.update(g.cfg.rule.rule_list)
+
     modify.db_backup()
 
     with closing(dbutil.connection(g.cfg.setting.database_file)) as cur:
-        for rule_version, rule_set in g.cfg.rule.data.items():
-            logging.info("%s", rule_set)
+        for rule_version in target_rule:
+            print(rule_version)
+            logging.info("%s", vars(g.cfg.rule.data.get(rule_version)))
             rows = cur.execute(
                 """
                 select

--- a/libs/utils/dictutil.py
+++ b/libs/utils/dictutil.py
@@ -207,8 +207,6 @@ def merge_dicts(dict1: dict[Any, Any], dict2: dict[Any, Any]) -> dict[Any, Any]:
 
         if isinstance(val1, (int, float)) and isinstance(val2, (int, float)):
             merged[key] = val1 + val2
-        elif isinstance(val1, str) and isinstance(val2, str):
-            merged[key] = val1 + val2
         elif isinstance(val1, list) and isinstance(val2, list):
             merged[key] = sorted(list(set(val1 + val2)))
         else:


### PR DESCRIPTION
This pull request enhances the `--recalculation` option in the `dbtools` utility to allow recalculation of points for specific rule versions, not just all at once. It updates both the command-line interface and the internal logic to support this flexibility, and adjusts documentation and type annotations accordingly. Additionally, it removes unnecessary string concatenation logic in the dictionary merging utility.

**Command-line interface and argument handling:**

* Changed the `--recalculation` option from a boolean flag to accept zero or more `RULE_VERSION` arguments, allowing users to specify which rule sets to recalculate. If no arguments are provided, all rule versions are recalculated. Updated help text and argument parsing to reflect this new behavior (`dbtools.py`, `libs/bootstrap/configuration.py`, `libs/domain/datamodels.py`). [[1]](diffhunk://#diff-8f4b3062a50ae63c0b7b40b9e35a910b1fc54fe177661d9c6652d4b566feffa6L31-R32) [[2]](diffhunk://#diff-8c497af399b75aabd2a36685b8298cffad1f10a333ef2e8e00aa4483294ec888L156-R159) [[3]](diffhunk://#diff-1b7508f2d219b2d1cd19bbeca40fbd19107c9e66c6b248c18b4f75e8568f3915L53-R53)

**Recalculation logic:**

* Modified the recalculation process to only target the specified rule versions, as determined by the command-line arguments. If no valid rule versions are specified, all are recalculated by default (`libs/functions/tools/recalculation.py`).

**Documentation updates:**

* Updated the command-line documentation to describe the new usage pattern for `--recalculation`, including the ability to specify rule versions and the default behavior when no arguments are given (`docs/user/source/commandline_tool/dbtools.rst`). [[1]](diffhunk://#diff-9d3e13f03f07da96aed167cf7a6b78b9c75867cb61e8ca0096b4bbef0c921a80L111-R115) [[2]](diffhunk://#diff-9d3e13f03f07da96aed167cf7a6b78b9c75867cb61e8ca0096b4bbef0c921a80L35) [[3]](diffhunk://#diff-9d3e13f03f07da96aed167cf7a6b78b9c75867cb61e8ca0096b4bbef0c921a80L94)

**Utility function cleanup:**

* Removed unnecessary string concatenation logic from the `merge_dicts` utility, as it was not needed for merging string values (`libs/utils/dictutil.py`).