### PR TITLE
Initialize configuration in placeholder function for proper setup

### DIFF
--- a/libs/utils/dictutil.py
+++ b/libs/utils/dictutil.py
@@ -40,6 +40,7 @@ def placeholder(subcom: "SubCommandLike", m: "MessageParserProtocol") -> Placeho
 
     """
     # 初期化
+    g.cfg.initialization()
     parser: CommandParser = CommandParser()
     params: PlaceholderBuilder = PlaceholderBuilder()
     rule_version: str | None = None


### PR DESCRIPTION
This pull request introduces a small update to the `libs/utils/dictutil.py` utility. The change ensures that the global configuration is properly initialized before proceeding with placeholder parsing logic.

- Added a call to `g.cfg.initialization()` at the start of the `placeholder` function to guarantee configuration is set up before use.