### PR TITLE
Enhance SettingSection with default reset and configuration improvements

### DIFF
--- a/libs/bootstrap/app_config.py
+++ b/libs/bootstrap/app_config.py
@@ -112,16 +112,16 @@ class AppConfig:
 
     def initialization(self) -> None:
         """設定ファイル読み込み"""
-        self.setting.config_load(self.main_parser["setting"])
-        self.alias.config_load(self.main_parser["alias"])
-        self.member.config_load(self.main_parser["member"])
-        self.team.config_load(self.main_parser["team"])
+        self.setting.initialization(self.main_parser["setting"])
+        self.alias.initialization(self.main_parser["alias"])
+        self.member.initialization(self.main_parser["member"])
+        self.team.initialization(self.main_parser["team"])
 
-        self.results.config_load(self.main_parser["results"])
-        self.graph.config_load(self.main_parser["graph"])
-        self.ranking.config_load(self.main_parser["ranking"])
-        self.report.config_load(self.main_parser["report"])
-        self.help.config_load(self.main_parser["help"])
+        self.results.initialization(self.main_parser["results"])
+        self.graph.initialization(self.main_parser["graph"])
+        self.ranking.initialization(self.main_parser["ranking"])
+        self.report.initialization(self.main_parser["report"])
+        self.help.initialization(self.main_parser["help"])
 
         # フォントファイルチェック
         for chk_dir in (self.config_dir, self.script_dir):
@@ -199,26 +199,26 @@ class AppConfig:
         protected_values: Union[str, list[str]]
         match section_name:
             case "setting":
-                self.setting.config_load(additional_config_parser[section_name])
+                self.setting.initialization(additional_config_parser[section_name])
             case "results":
                 protected_values = self.results.commandword  # 上書き保護
-                self.results.config_load(additional_config_parser[section_name])
+                self.results.initialization(additional_config_parser[section_name])
                 self.results.commandword = protected_values
             case "graph":
                 protected_values = self.graph.commandword  # 上書き保護
-                self.graph.config_load(additional_config_parser[section_name])
+                self.graph.initialization(additional_config_parser[section_name])
                 self.graph.commandword = protected_values
             case "ranking":
                 protected_values = self.ranking.commandword  # 上書き保護
-                self.ranking.config_load(additional_config_parser[section_name])
+                self.ranking.initialization(additional_config_parser[section_name])
                 self.ranking.commandword = protected_values
             case "report":
                 protected_values = self.report.commandword  # 上書き保護
-                self.report.config_load(additional_config_parser[section_name])
+                self.report.initialization(additional_config_parser[section_name])
                 self.report.commandword = protected_values
             case "help":
                 protected_values = self.help.commandword  # 上書き保護
-                self.help.config_load(additional_config_parser[section_name])
+                self.help.initialization(additional_config_parser[section_name])
                 self.help.commandword = protected_values
             case _:
                 return

--- a/libs/bootstrap/section.py
+++ b/libs/bootstrap/section.py
@@ -113,6 +113,11 @@ class BaseSection(CommonMethodMixin):
 
         """
         self.section_proxy = section_proxy
+
+        # 設定値取り込み前の初期化処理
+        if (reset_method := getattr(self, "default_reset", None)) and callable(reset_method):
+            reset_method()
+
         for k in self.section_proxy.keys():
             if k not in self.to_dict():
                 continue  # インスタンス変数と一致しない項目はスキップ
@@ -142,25 +147,9 @@ class BaseSection(CommonMethodMixin):
                 case _:
                     setattr(self, k, current_value)
 
-    def _before_config_load(self) -> None:
-        """設定値取り込み前の初期化処理"""
-        if (reset_method := getattr(self, "default_reset", None)) and callable(reset_method):
-            reset_method()
-
-    def _after_config_load(self, _section_proxy: "SectionProxy") -> None:
-        """設定値取り込み後の追加処理"""
-
-    def config_load(self, section_proxy: "SectionProxy") -> None:
-        """
-        設定値取り込み
-
-        Args:
-            section_proxy (SectionProxy): 読み込み先(パーサー + セクション名)
-
-        """
-        self._before_config_load()
-        self.initialization(section_proxy)
-        self._after_config_load(section_proxy)
+        # 設定値取り込み後の追加処理
+        if (after_method := getattr(self, "after_loading", None)) and callable(after_method):
+            after_method()
 
         logging.trace("%s: %s", self.section, self)  # type: ignore
 
@@ -271,10 +260,10 @@ class AliasSection(BaseSection):
     team_clear: list[str] = field(default_factory=lambda: ["team_clear"])
     """全チーム情報削除コマンド"""
 
-    def _after_config_load(self, _section_proxy: "SectionProxy") -> None:
+    def after_loading(self) -> None:
         """AliasSection専用の追加処理"""
 
-        # delのエイリアス取り込み(設定ファイルに`delete`と書かれていない)
+        # delのエイリアス取り込み(設定ファイルに ``delete`` と書かれていない)
         self.delete.extend(self.getlist("del", fallback="del"))
 
 

--- a/libs/bootstrap/section.py
+++ b/libs/bootstrap/section.py
@@ -3,7 +3,7 @@ libs/bootstrap/section.py
 """
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import MISSING, dataclass, field, fields
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, TypeAlias, Union
 
@@ -226,6 +226,14 @@ class SettingSection(BaseSection):
     """グラフスタイル"""
     work_dir: Path = field(default=Path("work"))
     """作業ディレクトリ"""
+
+    def default_reset(self) -> None:
+        """デフォルト値にリセット"""
+        for f in fields(self):
+            if f.default is not MISSING:
+                setattr(self, f.name, f.default)
+            elif f.default_factory is not MISSING:
+                setattr(self, f.name, f.default_factory())
 
 
 @dataclass

--- a/libs/commands/registry/member.py
+++ b/libs/commands/registry/member.py
@@ -12,7 +12,7 @@ from libs.types import CommandType
 from libs.utils import dbutil, textutil
 
 if TYPE_CHECKING:
-    from configparser import ConfigParser, SectionProxy
+    from configparser import ConfigParser
 
     from libs.bootstrap.app_config import AppConfig
 
@@ -64,9 +64,10 @@ class MemberSection(BaseSection):
         self.default_commandword = "メンバー一覧"
         self.section = str(CommandType.MEMBER_LIST)
         self.main_parser = outer.main_parser
-        self._reset()
+        self.default_reset()
 
-    def _reset(self) -> None:
+    def default_reset(self) -> None:
+        """デフォルト値にリセット"""
         self.info = []
         self.commandword = []
         self.command_suffix = []
@@ -75,18 +76,8 @@ class MemberSection(BaseSection):
         self.alias_limit = int(16)
         self.guest_name = str("ゲスト")
 
-    def config_load(self, section_proxy: "SectionProxy") -> None:
-        """
-        設定値取り込み
-
-        Args:
-            section_proxy (SectionProxy): 読み込み先(パーサー + セクション名)
-
-        """
-        self._reset()
-        self.initialization(section_proxy)
-
-        # 呼び出しキーワード取り込み
+    def after_loading(self) -> None:
+        """呼び出しキーワード取り込み"""
         self.commandword = self.getlist("commandword", fallback=self.default_commandword)
 
         logging.trace("%s: %s", self.section, self)  # type: ignore

--- a/libs/commands/registry/team.py
+++ b/libs/commands/registry/team.py
@@ -13,7 +13,7 @@ from libs.types import CommandType
 from libs.utils import dbutil, formatter, textutil
 
 if TYPE_CHECKING:
-    from configparser import ConfigParser, SectionProxy
+    from configparser import ConfigParser
 
     from libs.bootstrap.app_config import AppConfig
 
@@ -57,9 +57,10 @@ class TeamSection(BaseSection):
         self.default_commandword = "チーム一覧"
         self.section = str(CommandType.TEAM_LIST)
         self.main_parser = outer.main_parser
-        self._reset()
+        self.default_reset()
 
-    def _reset(self) -> None:
+    def default_reset(self) -> None:
+        """デフォルト値にリセット"""
         self.info = []
         self.commandword = []
         self.command_suffix = []
@@ -68,18 +69,8 @@ class TeamSection(BaseSection):
         self.member_limit = int(16)
         self.friendly_fire = bool(True)
 
-    def config_load(self, section_proxy: "SectionProxy") -> None:
-        """
-        設定値取り込み
-
-        Args:
-            section_proxy (SectionProxy): 読み込み先(パーサー + セクション名)
-
-        """
-        self._reset()
-        self.initialization(section_proxy)
-
-        # 呼び出しキーワード取り込み
+    def after_loading(self) -> None:
+        """呼び出しキーワード取り込み"""
         self.commandword = self.getlist("commandword", fallback=self.default_commandword)
 
         logging.trace("%s: %s", self.section, self)  # type: ignore

--- a/libs/utils/dictutil.py
+++ b/libs/utils/dictutil.py
@@ -74,7 +74,7 @@ def placeholder(subcom: "SubCommandLike", m: "MessageParserProtocol") -> Placeho
         params.separate = False  # DM / HomeApp(slack) はセパレートしない
 
     # ルール識別子探索
-    params.update_setting(main_config=g.cfg.config_file, key_name="default_rule", val_type=str)
+    params.update_setting(main_config=g.cfg.config_file, key_name="default_rule", val_type=str, fallback="default_rule")
     if (command_suffix := subcom.to_dict().get("command_suffix")) and isinstance(command_suffix, list):
         rule_version = lookup.get_current_rule_version(m, command_suffix)
     rule_version = rule_version if rule_version else params.default_rule

--- a/tests/test.py
+++ b/tests/test.py
@@ -87,6 +87,7 @@ def test_pattern(flag: dict[str, Any], test_case: str, sec: str, pattern: str, a
         )
 
     # ---------------------------------------------------------------------------------------------
+    configuration.setup()
     adapter = factory.select_adapter(ServiceType.STANDARD_IO, g.cfg)
     m = adapter.parser()
     target_loop: list[str] = []


### PR DESCRIPTION
This pull request refactors the configuration loading and initialization logic across several modules to improve consistency and extensibility. The main change is the replacement of the `config_load` method with a more structured approach using `initialization`, `default_reset`, and `after_loading` methods. This allows for clearer separation of concerns and easier customization for each section.

Key changes include:

**Configuration Loading Refactor:**

* Replaced calls to `config_load` with `initialization` in `AppConfig` methods, ensuring consistent initialization flow for all configuration sections. (`libs/bootstrap/app_config.py`) [[1]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212L115-R124) [[2]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212L202-R221)
* Removed the `config_load` method from `BaseSection` and replaced its logic by calling `default_reset` before loading values and `after_loading` after loading values, allowing for section-specific pre- and post-processing. (`libs/bootstrap/section.py`) [[1]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cR116-R120) [[2]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cL145-R152)

**Section Initialization Improvements:**

* Added a generic `default_reset` method to `SettingSection` (and similar logic in `AliasSection`, `MemberSection`, and `TeamSection`) to reset section attributes to their default values using dataclass field introspection. (`libs/bootstrap/section.py`, `libs/commands/registry/member.py`, `libs/commands/registry/team.py`) [[1]](diffhunk://#diff-37d225e608aa570eb745dfefe13dcea2595771367c291745dea3b58bf52d666cR219-R226) [[2]](diffhunk://#diff-0e3cabd708a159e090882ad6df087ebb438a78faf65d803150bd5d2b7a395029L67-R70) [[3]](diffhunk://#diff-e714f0a619367d58ae2d1b302e0bb27ab8aacd62d1dfd696d0ee1a6e42cbb7dcL60-R63)
* Standardized the naming and invocation of reset and post-load methods (`default_reset`, `after_loading`) in all relevant section classes for clarity and consistency. (`libs/commands/registry/member.py`, `libs/commands/registry/team.py`) [[1]](diffhunk://#diff-0e3cabd708a159e090882ad6df087ebb438a78faf65d803150bd5d2b7a395029L67-R70) [[2]](diffhunk://#diff-0e3cabd708a159e090882ad6df087ebb438a78faf65d803150bd5d2b7a395029L78-R80) [[3]](diffhunk://#diff-e714f0a619367d58ae2d1b302e0bb27ab8aacd62d1dfd696d0ee1a6e42cbb7dcL60-R63) [[4]](diffhunk://#diff-e714f0a619367d58ae2d1b302e0bb27ab8aacd62d1dfd696d0ee1a6e42cbb7dcL71-R73)

**Minor and Supporting Changes:**

* Updated type hints and imports to remove unused references to `SectionProxy` where no longer necessary. (`libs/commands/registry/member.py`, `libs/commands/registry/team.py`) [[1]](diffhunk://#diff-0e3cabd708a159e090882ad6df087ebb438a78faf65d803150bd5d2b7a395029L15-R15) [[2]](diffhunk://#diff-e714f0a619367d58ae2d1b302e0bb27ab8aacd62d1dfd696d0ee1a6e42cbb7dcL16-R16)
* Minor bugfix: Added a fallback value when updating settings in `dictutil.py`.
* Added a call to `configuration.setup()` in the test to ensure proper setup before running the test logic. (`tests/test.py`)
* Minor import clean-up in `section.py`.

These changes improve the maintainability and extensibility of the configuration system by introducing clear extension points and reducing code duplication.