### PR TITLE
Refactor imports for consistency and bump version to 0.14.7

### DIFF
--- a/integrations/discord/config.py
+++ b/integrations/discord/config.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 
 from integrations.base.interface import IntegrationsConfig
 from integrations.discord.events import comparison
-from libs.bootstrap.section import BaseSection
+from libs.domain.section import BaseSection
 
 if TYPE_CHECKING:
     from pathlib import Path  # noqa: F401

--- a/integrations/discord/events/comparison.py
+++ b/integrations/discord/events/comparison.py
@@ -10,10 +10,10 @@ from discord import Message
 from discord.channel import TextChannel
 
 import libs.global_value as g
-from libs.domain import modify, validator
+from libs.domain import modify
 from libs.domain.datamodels import ComparisonResults
 from libs.domain.score import GameResult
-from libs.functions import search
+from libs.functions import search, validator
 from libs.types import ActionStatus, CommandType, RemarkDict, StyleOptions
 from libs.utils import formatter
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/integrations/slack/config.py
+++ b/integrations/slack/config.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from integrations.base.interface import IntegrationsConfig
 from integrations.slack.events import comparison, slash
-from libs.bootstrap.section import BaseSection
+from libs.domain.section import BaseSection
 
 if TYPE_CHECKING:
     from pathlib import Path  # noqa: F401

--- a/integrations/slack/events/comparison.py
+++ b/integrations/slack/events/comparison.py
@@ -6,10 +6,10 @@ import logging
 from typing import TYPE_CHECKING, cast
 
 import libs.global_value as g
-from libs.domain import modify, validator
+from libs.domain import modify
 from libs.domain.datamodels import ComparisonResults
 from libs.domain.score import GameResult
-from libs.functions import lookup, search
+from libs.functions import lookup, search, validator
 from libs.types import ActionStatus, CommandType, StyleOptions
 from libs.utils import formatter
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/integrations/slack/functions.py
+++ b/integrations/slack/functions.py
@@ -7,8 +7,7 @@ from typing import TYPE_CHECKING, Any, Union, cast
 
 import libs.global_value as g
 from integrations.base.interface import FunctionsInterface
-from libs.domain import validator
-from libs.functions import lookup
+from libs.functions import lookup, validator
 from libs.types import ActionStatus
 from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/integrations/standard_io/config.py
+++ b/integrations/standard_io/config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from integrations.base.interface import IntegrationsConfig
-from libs.bootstrap.section import BaseSection
+from libs.domain.section import BaseSection
 
 if TYPE_CHECKING:
     from pathlib import Path  # noqa: F401

--- a/integrations/web/config.py
+++ b/integrations/web/config.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Literal
 
 import libs.global_value as g
 from integrations.base.interface import IntegrationsConfig
-from libs.bootstrap.section import BaseSection
+from libs.domain.section import BaseSection
 
 if TYPE_CHECKING:
     from pathlib import Path  # noqa: F401

--- a/libs/bootstrap/__init__.py
+++ b/libs/bootstrap/__init__.py
@@ -3,6 +3,5 @@
 
 - :doc:`libs.bootstrap.configuration`: 初期設定関数
 - :doc:`libs.bootstrap.app_config`: アプリケーション設定関連
-- :doc:`libs.bootstrap.section`: セクション情報取り込み
 - :doc:`libs.bootstrap.initialization`: 各種初期化処理
 """

--- a/libs/bootstrap/app_config.py
+++ b/libs/bootstrap/app_config.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional, Union
 
-from libs.bootstrap.section import AliasSection, BaseSection, SettingSection, SubCommands
 from libs.commands.graph.entry import GraphConfig
 from libs.commands.help.entry import HelpConfig
 from libs.commands.ranking.entry import RankingConfig
@@ -18,6 +17,7 @@ from libs.commands.registry.team import TeamSection
 from libs.commands.report.entry import ReportConfig
 from libs.commands.results.entry import ResultsConfig
 from libs.domain.rule import RuleSet
+from libs.domain.section import AliasSection, BaseSection, SettingSection, SubCommands
 from libs.functions.lookup import read_memberslist
 from libs.types import CommandType, GradeTableDict, ServiceType
 

--- a/libs/bootstrap/configuration.py
+++ b/libs/bootstrap/configuration.py
@@ -28,7 +28,7 @@ from libs.types import ServiceType, StyleOptions
 
 if TYPE_CHECKING:
     from integrations.protocols import MessageParserProtocol
-    from libs.bootstrap.section import SubCommands
+    from libs.domain.section import SubCommands
 
 
 def set_loglevel() -> None:

--- a/libs/commands/graph/entry.py
+++ b/libs/commands/graph/entry.py
@@ -5,8 +5,8 @@ libs/commands/graph/entry.py
 from typing import TYPE_CHECKING
 
 import libs.global_value as g
-from libs.bootstrap.section import SubCommands
 from libs.commands.graph import personal, rating, summary
+from libs.domain.section import SubCommands
 from libs.types import CommandType
 from libs.utils import dictutil
 

--- a/libs/commands/help/entry.py
+++ b/libs/commands/help/entry.py
@@ -6,7 +6,7 @@ import textwrap
 from typing import TYPE_CHECKING
 
 import libs.global_value as g
-from libs.bootstrap.section import SubCommands
+from libs.domain.section import SubCommands
 from libs.functions import lookup
 from libs.types import CommandType, StyleOptions
 from libs.utils import dictutil, formatter

--- a/libs/commands/ranking/entry.py
+++ b/libs/commands/ranking/entry.py
@@ -5,8 +5,8 @@ libs/commands/ranking/entry.py
 from typing import TYPE_CHECKING
 
 import libs.global_value as g
-from libs.bootstrap.section import SubCommands
 from libs.commands.ranking import ranking, rating
+from libs.domain.section import SubCommands
 from libs.types import CommandType
 from libs.utils import dictutil
 

--- a/libs/commands/registry/member.py
+++ b/libs/commands/registry/member.py
@@ -6,8 +6,8 @@ import logging
 from typing import TYPE_CHECKING, TypedDict, cast
 
 import libs.global_value as g
-from libs.bootstrap.section import BaseSection
 from libs.domain import modify, validator
+from libs.domain.section import BaseSection
 from libs.types import CommandType
 from libs.utils import dbutil, textutil
 

--- a/libs/commands/registry/member.py
+++ b/libs/commands/registry/member.py
@@ -6,8 +6,9 @@ import logging
 from typing import TYPE_CHECKING, TypedDict, cast
 
 import libs.global_value as g
-from libs.domain import modify, validator
+from libs.domain import modify
 from libs.domain.section import BaseSection
+from libs.functions import validator
 from libs.types import CommandType
 from libs.utils import dbutil, textutil
 

--- a/libs/commands/registry/team.py
+++ b/libs/commands/registry/team.py
@@ -7,8 +7,9 @@ from typing import TYPE_CHECKING, TypedDict, cast
 
 import libs.global_value as g
 from libs.bootstrap import initialization
-from libs.domain import modify, validator
+from libs.domain import modify
 from libs.domain.section import BaseSection
+from libs.functions import validator
 from libs.types import CommandType
 from libs.utils import dbutil, formatter, textutil
 

--- a/libs/commands/registry/team.py
+++ b/libs/commands/registry/team.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, TypedDict, cast
 
 import libs.global_value as g
 from libs.bootstrap import initialization
-from libs.bootstrap.section import BaseSection
 from libs.domain import modify, validator
+from libs.domain.section import BaseSection
 from libs.types import CommandType
 from libs.utils import dbutil, formatter, textutil
 

--- a/libs/commands/report/entry.py
+++ b/libs/commands/report/entry.py
@@ -5,8 +5,8 @@ libs/commands/report/entry.py
 from typing import TYPE_CHECKING
 
 import libs.global_value as g
-from libs.bootstrap.section import SubCommands
 from libs.commands.report import matrix, monthly, stats_list, stats_report, winner
+from libs.domain.section import SubCommands
 from libs.types import CommandType
 from libs.utils import dictutil
 

--- a/libs/commands/results/entry.py
+++ b/libs/commands/results/entry.py
@@ -5,8 +5,8 @@ libs/commands/results/entry.py
 from typing import TYPE_CHECKING
 
 import libs.global_value as g
-from libs.bootstrap.section import SubCommands
 from libs.commands.results import detail, summary, versus
+from libs.domain.section import SubCommands
 from libs.types import CommandType
 from libs.utils import dictutil
 

--- a/libs/dispatcher.py
+++ b/libs/dispatcher.py
@@ -7,9 +7,9 @@ from typing import TYPE_CHECKING
 
 import libs.global_value as g
 from integrations import factory
-from libs.domain import modify, validator
+from libs.domain import modify
 from libs.domain.score import GameResult
-from libs.functions import lookup, message
+from libs.functions import lookup, message, validator
 from libs.types import MessageStatus, StyleOptions
 from libs.utils import formatter
 

--- a/libs/domain/__init__.py
+++ b/libs/domain/__init__.py
@@ -10,5 +10,4 @@
 - :doc:`libs.domain.placeholder`: プレースホルダ構築
 - :doc:`libs.domain.aggregate`: データ集計
 - :doc:`libs.domain.modify`: DBデータ操作
-- :doc:`libs.domain.validator`: バリデータ
 """

--- a/libs/domain/__init__.py
+++ b/libs/domain/__init__.py
@@ -2,6 +2,7 @@
 アプリケーションロジック
 
 - :doc:`libs.domain.datamodels`: データモデル
+- :doc:`libs.domain.section`: 設定ファイル取り込み
 - :doc:`libs.domain.command`: コマンド引数解析
 - :doc:`libs.domain.score`: スコア解析
 - :doc:`libs.domain.stats`: 成績解析

--- a/libs/domain/section.py
+++ b/libs/domain/section.py
@@ -1,5 +1,5 @@
 """
-libs/bootstrap/section.py
+libs/domain/section.py
 """
 
 import logging

--- a/libs/functions/__init__.py
+++ b/libs/functions/__init__.py
@@ -7,4 +7,6 @@
 - :doc:`libs.functions.compose`: メッセージ生成
 - :doc:`libs.functions.adjusting`: 表・桁数・調整
 - :doc:`libs.functions.tools`: 外部ツール用モジュール
+- :doc:`libs.functions.validator`: バリデータ
+
 """

--- a/libs/functions/lookup.py
+++ b/libs/functions/lookup.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from integrations.protocols import MessageParserProtocol
-    from libs.bootstrap.section import SubCommands
+    from libs.domain.section import SubCommands
 
 
 def get_config_value(

--- a/libs/functions/tools/unification.py
+++ b/libs/functions/tools/unification.py
@@ -6,8 +6,8 @@ import configparser
 import logging
 
 import libs.global_value as g
-from libs.domain import modify, validator
-from libs.functions import lookup
+from libs.domain import modify
+from libs.functions import lookup, validator
 from libs.utils import dbutil, textutil
 
 

--- a/libs/functions/validator.py
+++ b/libs/functions/validator.py
@@ -1,5 +1,5 @@
 """
-libs/utils/validator.py
+libs/functions/validator.py
 """
 
 import re

--- a/libs/utils/formatter.py
+++ b/libs/utils/formatter.py
@@ -7,7 +7,7 @@ import re
 from typing import Optional, cast
 
 import libs.global_value as g
-from libs.bootstrap.section import SubCommands
+from libs.domain.section import SubCommands
 from libs.types import StyleOptions
 from libs.utils import dictutil, textutil
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mahjong-score-management"
-version = "0.14.6"
+version = "0.14.7"
 description = "Mahjong score management tool"
 readme = "README.md"
 license = "MIT"

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -16,7 +16,7 @@ from libs.commands.report.entry import ReportConfig
 from libs.commands.results.entry import ResultsConfig
 
 if TYPE_CHECKING:
-    from libs.bootstrap.section import SubCommands
+    from libs.domain.section import SubCommands
 
 
 def test_empty_config(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/config/test_keyword.py
+++ b/tests/config/test_keyword.py
@@ -12,7 +12,7 @@ from libs.bootstrap import configuration
 from tests.config import param_data
 
 if TYPE_CHECKING:
-    from libs.bootstrap.section import SubCommands
+    from libs.domain.section import SubCommands
 
 
 @pytest.mark.parametrize(

--- a/tests/database/test_result_update.py
+++ b/tests/database/test_result_update.py
@@ -10,8 +10,9 @@ import pytest
 import libs.global_value as g
 from integrations import factory
 from libs.bootstrap import configuration, initialization
-from libs.domain import modify, validator
+from libs.domain import modify
 from libs.domain.score import GameResult
+from libs.functions import validator
 from libs.types import ServiceType
 from libs.utils import dbutil
 from libs.utils.timekit import ExtendedDatetime as ExtDt

--- a/tests/name_check/test_name.py
+++ b/tests/name_check/test_name.py
@@ -8,8 +8,7 @@ from typing import Any, Generator
 import pytest
 
 from libs.bootstrap import configuration
-from libs.domain import validator
-from libs.functions import lookup
+from libs.functions import lookup, validator
 from tests.name_check import param_data
 
 TEST_ARGS = ["progname", "--config=tests/test_data/saki.ini"]

--- a/tests/parser/test_score.py
+++ b/tests/parser/test_score.py
@@ -10,8 +10,8 @@ import pytest
 import libs.global_value as g
 from integrations import factory
 from libs.bootstrap import configuration, initialization
-from libs.domain import validator
 from libs.domain.score import GameResult
+from libs.functions import validator
 from libs.types import ServiceType
 from tests.parser import param_data
 


### PR DESCRIPTION
This pull request primarily refactors the codebase to move the `section.py` module and related classes from the `libs/bootstrap` package to `libs/domain`, and updates all imports accordingly. Additionally, it reorganizes some imports to improve code clarity and maintainability.

Key changes include:

### Refactor: Move Section Module

* Renamed and relocated `libs/bootstrap/section.py` to `libs/domain/section.py`, updating all references throughout the codebase to import from the new location. [[1]](diffhunk://#diff-d2d3197229f61bfab42d654bd57c7d0d34434f0df1ce70f8acf6f83a6b4c0f6eL2-R2) [[2]](diffhunk://#diff-9c24723dba3cb102da36ca782c93b643af26fab87a0ead8c7bce77107136bf65L11-R11) [[3]](diffhunk://#diff-4539bcd967bff69fc3046323ea8f50baa5061b27e03176b0bfb11820bfe47b0eL11-R11) [[4]](diffhunk://#diff-6231ae1fb0642cbe61463c971b1cf5ffb9ea6840abb9a7160e01ecb3f8ba4ebbL10-R10) [[5]](diffhunk://#diff-12a3093dc167bb1a88424a996519782e246388b37c15b0b9c11b67428b3d6e95L12-R12) [[6]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212L12) [[7]](diffhunk://#diff-e2dc817c0b0314b36d8398e22ab2625d57d14afc489292a8480e784f83dcb212R20) [[8]](diffhunk://#diff-8c497af399b75aabd2a36685b8298cffad1f10a333ef2e8e00aa4483294ec888L31-R31) [[9]](diffhunk://#diff-b8cb47706451cf132fb00329d13f047e7ea10fcfd76e7a420d814588dde033deL8-R9) [[10]](diffhunk://#diff-50f3210c9b6448a619d76ec07b7b40c0cb71eb9866414548f005c8c0b0c62dc9L9-R9) [[11]](diffhunk://#diff-6e7de3e653827fa05b18ac4acb781fad85e3b92ee540c0b5808b96f31b02290dL8-R9) [[12]](diffhunk://#diff-0e3cabd708a159e090882ad6df087ebb438a78faf65d803150bd5d2b7a395029L9-R11) [[13]](diffhunk://#diff-e714f0a619367d58ae2d1b302e0bb27ab8aacd62d1dfd696d0ee1a6e42cbb7dcL10-R12) [[14]](diffhunk://#diff-bc02d231488604bbfc1df0ddf38c57465c911a51b8e818b8ba5dab4ab8929f77L8-R9) [[15]](diffhunk://#diff-6b1a16063303e31de3584d2fb77a7dbf73d965b6bb14e0c1c37b4c79bededc10L8-R9)

### Import Organization

* Consolidated and clarified imports for `validator` and related functions, moving some imports from `libs.domain` to `libs.functions` to better reflect their usage and logical grouping. [[1]](diffhunk://#diff-dbe08a2e2ba59bcf3e91478b11948a38136080e684d2f299f31282b0d0460ee6L13-R16) [[2]](diffhunk://#diff-15aefd5123d19b186d8d9a71ece2a26a72bfbecb3ce74bcbad19f684cadd2939L9-R12) [[3]](diffhunk://#diff-cef30475cb7daff0cdd5651691253c9f22bf28fbaa91336867c2dca24cfa7d44L10-R10) [[4]](diffhunk://#diff-0e3cabd708a159e090882ad6df087ebb438a78faf65d803150bd5d2b7a395029L9-R11) [[5]](diffhunk://#diff-e714f0a619367d58ae2d1b302e0bb27ab8aacd62d1dfd696d0ee1a6e42cbb7dcL10-R12) [[6]](diffhunk://#diff-f7f2d5ef6441ca6bd83fb6b712c662c54bbab01a8f8dd2c6e9aa04e5a8082609L10-R12)

### Documentation Updates

* Updated documentation comments to reflect the new module locations and removed outdated references to the old `libs.bootstrap.section` location. [[1]](diffhunk://#diff-89d8ede0504e55850185d055d5a095a633c48fc7862fd18360114cee421d433cL6) [[2]](diffhunk://#diff-28c9542cbbe5badb9f51ad8a0f52f6a887f24d8fe70566c2acb0c3bc893f33b0R5-L12)

These changes help to clarify the structure of the codebase, making it easier to maintain and extend configuration and section-related functionality in the future.