### PR TITLE
Update README API reference and StatusData documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,4 @@
 https://togakushi.github.io/mahjong-score-management/user/
 
 ## 開発資料 (APIリファレンス)
-https://togakushi.github.io/mahjong-score-management/dev/
+https://togakushi.github.io/mahjong-score-management/api/

--- a/integrations/protocols.py
+++ b/integrations/protocols.py
@@ -106,6 +106,7 @@ class StatusData(DataMixin):
 
     result: bool = field(default=True)
     """メッセージデータに対する処理結果
+
     - *True*: 目的の処理が達成できた
     - *False*: 何らかの原因で処理が達成できなかった
     """


### PR DESCRIPTION
This pull request includes minor documentation and formatting updates. The most notable changes are:

Documentation:

* Updated the development API reference link in `docs/README.md` to point to the new `/api/` path instead of `/dev/`.

Code formatting:

* Added a blank line for improved readability in the docstring of the `result` field in the `StatusData` class in `integrations/protocols.py`.