### PR TITLE
Refactor time formatting to use ExtDt constants

### DIFF
--- a/integrations/discord/api.py
+++ b/integrations/discord/api.py
@@ -15,7 +15,6 @@ import integrations.discord.events.audioop as _audioop
 from integrations.base.interface import APIInterface
 from libs.types import CommandType, StyleOptions
 from libs.utils import converter, textutil
-from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 
 sys.modules["audioop"] = _audioop
@@ -153,7 +152,7 @@ class AdapterAPI(APIInterface):
                 post_msg = textutil.group_strings(post_msg, limit=1800)
 
         if thread_msg and m.post.thread:
-            date_suffix = ExtDt(float(m.data.event_ts)).format(Format.YMDHMS, Delimiter.SLASH)
+            date_suffix = ExtDt(float(m.data.event_ts)).format(ExtDt.FMT.YMDHMS, ExtDt.DEM.SLASH)
             if not m.post.thread_title.isnumeric() and m.post.thread_title:
                 thread = await thread_msg.create_thread(name=f"{m.post.thread_title} - {date_suffix}")
                 for msg in post_msg:

--- a/integrations/slack/events/handler.py
+++ b/integrations/slack/events/handler.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, cast
 import libs.dispatcher
 from integrations.slack.events.handler_registry import register, register_all
 from integrations.slack.events.home_tab import home
-from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 
 if TYPE_CHECKING:
@@ -109,8 +108,8 @@ def register_event_handlers(app: "App", adapter: "ServiceAdapter") -> None:
             "view_id": None,
             "screen": None,
             "operation": None,
-            "sday": adapter.conf.tab_var.get("sday", ExtDt().format(Format.YMD, Delimiter.HYPHEN)),
-            "eday": adapter.conf.tab_var.get("eday", ExtDt().format(Format.YMD, Delimiter.HYPHEN)),
+            "sday": adapter.conf.tab_var.get("sday", ExtDt().format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN)),
+            "eday": adapter.conf.tab_var.get("eday", ExtDt().format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN)),
         }
 
         adapter.conf.tab_var["user_id"] = event["user"]

--- a/integrations/slack/events/home_tab/personal.py
+++ b/integrations/slack/events/home_tab/personal.py
@@ -12,7 +12,6 @@ from integrations.slack.events.home_tab import ui_parts
 from libs.commands.results import detail
 from libs.types import CommandType
 from libs.utils import dictutil
-from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 
 if TYPE_CHECKING:
@@ -33,15 +32,15 @@ def build_personal_menu(adapter: ServiceAdapter) -> "View":
     adapter.conf.tab_var["screen"] = "PersonalMenu"
     adapter.conf.tab_var["no"] = 0
     adapter.conf.tab_var["view"] = {"type": "home", "blocks": []}
-    adapter.conf.tab_var.setdefault("sday", ExtDt().format(Format.YMD, Delimiter.HYPHEN))
-    adapter.conf.tab_var.setdefault("eday", ExtDt().format(Format.YMD, Delimiter.HYPHEN))
+    adapter.conf.tab_var.setdefault("sday", ExtDt().format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN))
+    adapter.conf.tab_var.setdefault("eday", ExtDt().format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN))
     ui_parts.header(adapter, text="【個人成績】")
 
     # プレイヤー選択リスト
     ui_parts.user_select_pulldown(adapter, text="対象プレイヤー")
 
     # 検索範囲設定
-    date_dict = {x: ExtDt(hours=-g.cfg.setting.time_adjust).range(x).dict_format(Format.YMD, Delimiter.HYPHEN) for x in ["今月", "先月", "全部"]}
+    date_dict = {x: ExtDt(hours=-g.cfg.setting.time_adjust).range(x).dict_format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN) for x in ["今月", "先月", "全部"]}
     ui_parts.divider(adapter)
     ui_parts.radio_buttons(
         adapter=adapter,

--- a/integrations/slack/events/home_tab/ranking.py
+++ b/integrations/slack/events/home_tab/ranking.py
@@ -12,7 +12,6 @@ from integrations.slack.events.home_tab import ui_parts
 from libs.commands.ranking import ranking
 from libs.types import CommandType
 from libs.utils import dictutil
-from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 
 if TYPE_CHECKING:
@@ -33,12 +32,12 @@ def build_ranking_menu(adapter: ServiceAdapter) -> "View":
     adapter.conf.tab_var["screen"] = "RankingMenu"
     adapter.conf.tab_var["no"] = 0
     adapter.conf.tab_var["view"] = {"type": "home", "blocks": []}
-    adapter.conf.tab_var.setdefault("sday", ExtDt().format(Format.YMD, Delimiter.HYPHEN))
-    adapter.conf.tab_var.setdefault("eday", ExtDt().format(Format.YMD, Delimiter.HYPHEN))
+    adapter.conf.tab_var.setdefault("sday", ExtDt().format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN))
+    adapter.conf.tab_var.setdefault("eday", ExtDt().format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN))
     ui_parts.header(adapter, text="【ランキング】")
 
     # 検索範囲設定
-    date_dict = {x: ExtDt(hours=-g.cfg.setting.time_adjust).range(x).dict_format(Format.YMD, Delimiter.HYPHEN) for x in ["今月", "先月", "全部"]}
+    date_dict = {x: ExtDt(hours=-g.cfg.setting.time_adjust).range(x).dict_format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN) for x in ["今月", "先月", "全部"]}
     ui_parts.divider(adapter)
     ui_parts.radio_buttons(
         adapter=adapter,

--- a/integrations/slack/events/home_tab/summary.py
+++ b/integrations/slack/events/home_tab/summary.py
@@ -14,7 +14,6 @@ from libs.commands.ranking import rating
 from libs.commands.results import summary as results_summary
 from libs.types import CommandType
 from libs.utils import dictutil
-from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 
 if TYPE_CHECKING:
@@ -29,12 +28,12 @@ def build_summary_menu(adapter: ServiceAdapter) -> "View":
     adapter.conf.tab_var["screen"] = "SummaryMenu"
     adapter.conf.tab_var["no"] = 0
     adapter.conf.tab_var["view"] = {"type": "home", "blocks": []}
-    adapter.conf.tab_var.setdefault("sday", ExtDt().format(Format.YMD, Delimiter.HYPHEN))
-    adapter.conf.tab_var.setdefault("eday", ExtDt().format(Format.YMD, Delimiter.HYPHEN))
+    adapter.conf.tab_var.setdefault("sday", ExtDt().format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN))
+    adapter.conf.tab_var.setdefault("eday", ExtDt().format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN))
     ui_parts.header(adapter, text="【成績サマリ】")
 
     # 検索範囲設定
-    date_dict = {x: ExtDt(hours=-g.cfg.setting.time_adjust).range(x).dict_format(Format.YMD, Delimiter.HYPHEN) for x in ["今月", "先月", "全部"]}
+    date_dict = {x: ExtDt(hours=-g.cfg.setting.time_adjust).range(x).dict_format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN) for x in ["今月", "先月", "全部"]}
     ui_parts.divider(adapter)
     ui_parts.radio_buttons(
         adapter=adapter,

--- a/integrations/slack/events/home_tab/versus.py
+++ b/integrations/slack/events/home_tab/versus.py
@@ -12,7 +12,6 @@ from integrations.slack.events.home_tab import ui_parts
 from libs.commands.results import versus
 from libs.types import CommandType
 from libs.utils import dictutil
-from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 
 if TYPE_CHECKING:
@@ -27,8 +26,8 @@ def build_versus_menu(adapter: ServiceAdapter) -> "View":
     adapter.conf.tab_var["screen"] = "VersusMenu"
     adapter.conf.tab_var["no"] = 0
     adapter.conf.tab_var["view"] = {"type": "home", "blocks": []}
-    adapter.conf.tab_var.setdefault("sday", ExtDt().format(Format.YMD, Delimiter.HYPHEN))
-    adapter.conf.tab_var.setdefault("eday", ExtDt().format(Format.YMD, Delimiter.HYPHEN))
+    adapter.conf.tab_var.setdefault("sday", ExtDt().format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN))
+    adapter.conf.tab_var.setdefault("eday", ExtDt().format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN))
     ui_parts.header(adapter, text="【直接対戦】")
 
     # プレイヤー選択リスト
@@ -36,7 +35,7 @@ def build_versus_menu(adapter: ServiceAdapter) -> "View":
     ui_parts.multi_select_pulldown(adapter, text="対戦相手", add_list=["全員"])
 
     # 検索範囲設定
-    date_dict = {x: ExtDt(hours=-g.cfg.setting.time_adjust).range(x).dict_format(Format.YMD, Delimiter.HYPHEN) for x in ["今月", "先月", "全部"]}
+    date_dict = {x: ExtDt(hours=-g.cfg.setting.time_adjust).range(x).dict_format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN) for x in ["今月", "先月", "全部"]}
     ui_parts.divider(adapter)
     ui_parts.radio_buttons(
         adapter=adapter,

--- a/integrations/slack/functions.py
+++ b/integrations/slack/functions.py
@@ -9,7 +9,6 @@ import libs.global_value as g
 from integrations.base.interface import FunctionsInterface
 from libs.functions import lookup, validator
 from libs.types import ActionStatus
-from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 
 if TYPE_CHECKING:
@@ -55,7 +54,7 @@ class SvcFunctions(FunctionsInterface):
             words = " ".join(words)
 
         # 検索クエリ
-        after = ExtDt(days=-self.conf.search_after, hours=g.cfg.setting.time_adjust).format(Format.YMD, Delimiter.HYPHEN)
+        after = ExtDt(days=-self.conf.search_after, hours=g.cfg.setting.time_adjust).format(ExtDt.FMT.YMD, ExtDt.DEM.HYPHEN)
         channel = " ".join([f"in:{x}" for x in self.conf.search_channel])
         query = f"{words} {channel} after:{after}"
         logging.info("query=%s, check_db=%s", query, g.cfg.setting.database_file)

--- a/libs/functions/compose/text_item.py
+++ b/libs/functions/compose/text_item.py
@@ -7,11 +7,11 @@ from typing import TYPE_CHECKING, Literal, Optional
 from table2ascii import Alignment, PresetStyle, table2ascii
 
 import libs.global_value as g
-from libs.utils.timekit import Delimiter, Format
 from libs.utils.timekit import ExtendedDatetime as ExtDt
 
 if TYPE_CHECKING:
     from libs.domain.datamodels import GameInfo
+    from libs.utils.timekit import Format
 
 
 def remarks(headword: bool = False) -> str | list[str]:
@@ -114,14 +114,14 @@ def search_range(kind: Literal["str", "list"] = "str", time_pattern: Optional[st
 
     match time_pattern:
         case "day":
-            starttime = ExtDt(g.params.starttime).format(Format.TS)
-            endtime = ExtDt(g.params.endtime).format(Format.TS)
+            starttime = ExtDt(g.params.starttime).format(ExtDt.FMT.TS)
+            endtime = ExtDt(g.params.endtime).format(ExtDt.FMT.TS)
         case "time":
-            starttime = ExtDt(g.params.starttime).format(Format.YMDHM)
-            endtime = ExtDt(g.params.endtime).format(Format.YMDHM)
+            starttime = ExtDt(g.params.starttime).format(ExtDt.FMT.YMDHM)
+            endtime = ExtDt(g.params.endtime).format(ExtDt.FMT.YMDHM)
         case _:
-            starttime = ExtDt(g.params.starttime).format(Format.YMDHMS)
-            endtime = ExtDt(g.params.endtime).format(Format.YMDHMS)
+            starttime = ExtDt(g.params.starttime).format(ExtDt.FMT.YMDHMS)
+            endtime = ExtDt(g.params.endtime).format(ExtDt.FMT.YMDHMS)
 
     if g.params.anonymous:
         starttime = "yyyy/mm/dd HH:MM"
@@ -161,8 +161,8 @@ def aggregation_range(
         first = game_info.first_comment
         last = game_info.last_comment
     else:
-        first = game_info.first_game.format(Format.YMDHM)
-        last = game_info.last_game.format(Format.YMDHM)
+        first = game_info.first_game.format(ExtDt.FMT.YMDHM)
+        last = game_info.last_game.format(ExtDt.FMT.YMDHM)
 
     match kind:
         case "list":
@@ -172,7 +172,7 @@ def aggregation_range(
 
 
 def date_range(
-    kind: Format,
+    kind: "Format",
     prefix_a: Optional[str] = None,
     prefix_b: Optional[str] = None,
 ) -> str:
@@ -202,7 +202,7 @@ def date_range(
         str_st = st.format(kind)
         str_et = et.format(kind)
 
-    if st.format(kind, Delimiter.NUMBER) == ot.format(kind, Delimiter.NUMBER):
+    if st.format(kind, ExtDt.DEM.NUMBER) == ot.format(kind, ExtDt.DEM.NUMBER):
         if prefix_a and prefix_b:
             ret = f"{prefix_a} ({str_st})"
         else:


### PR DESCRIPTION
This pull request refactors how date and time formatting options are referenced throughout the codebase. Instead of importing and using the `Format` and `Delimiter` enums directly, the code now uses the `FMT` and `DEM` attributes on the `ExtendedDatetime` (`ExtDt`) class. This change improves encapsulation and makes the usage of formatting options more consistent and explicit.

Key changes include:

**Refactoring date/time formatting usage:**

* Replaced all instances of `Format.X` and `Delimiter.Y` with `ExtDt.FMT.X` and `ExtDt.DEM.Y` respectively in calls to `ExtDt.format()` and related methods across multiple files, including `integrations/discord/api.py`, `integrations/slack/events/handler.py`, `integrations/slack/events/home_tab/personal.py`, `integrations/slack/events/home_tab/ranking.py`, `integrations/slack/events/home_tab/summary.py`, `integrations/slack/events/home_tab/versus.py`, `integrations/slack/functions.py`, and `libs/functions/compose/text_item.py`. [[1]](diffhunk://#diff-e70f2c4ac2e5530abf5bae8dede764a1abe586aec1781fb4dd21c822d3828c7bL156-R155) [[2]](diffhunk://#diff-5749a903b8fc6113c42260a59d8041b74de127246096dbfb64ab8da0739e097fL112-R112) [[3]](diffhunk://#diff-110dedcbd8762e9c4a5c1def1ed8cc7f118adb2a8afce710c68a6047b5c12c9dL36-R43) [[4]](diffhunk://#diff-98fec2643e2da9d619885c3254256a2914a1bfcc9eecf8d91bab5c084d074155L36-R40) [[5]](diffhunk://#diff-8c2643c908331a43430aedfa9a5c3f006959b1c0c29feb975cf45ece8830b8d7L32-R36) [[6]](diffhunk://#diff-23baa78319a7052e993f6ca661ab309cf3f43dbcdf2e2ab0782ddb859f0adec0L30-R38) [[7]](diffhunk://#diff-cef30475cb7daff0cdd5651691253c9f22bf28fbaa91336867c2dca24cfa7d44L58-R57) [[8]](diffhunk://#diff-2abfd9960a0cf80a1c8c57d1290dfbabc3adbcd0476fcb8b101b7459723d8f34L117-R124) [[9]](diffhunk://#diff-2abfd9960a0cf80a1c8c57d1290dfbabc3adbcd0476fcb8b101b7459723d8f34L164-R165) [[10]](diffhunk://#diff-2abfd9960a0cf80a1c8c57d1290dfbabc3adbcd0476fcb8b101b7459723d8f34L205-R205)

**Cleanup of unused imports:**

* Removed unused imports of `Format` and `Delimiter` from files that now reference them via `ExtDt.FMT` and `ExtDt.DEM`. [[1]](diffhunk://#diff-e70f2c4ac2e5530abf5bae8dede764a1abe586aec1781fb4dd21c822d3828c7bL18) [[2]](diffhunk://#diff-5749a903b8fc6113c42260a59d8041b74de127246096dbfb64ab8da0739e097fL13) [[3]](diffhunk://#diff-110dedcbd8762e9c4a5c1def1ed8cc7f118adb2a8afce710c68a6047b5c12c9dL15) [[4]](diffhunk://#diff-98fec2643e2da9d619885c3254256a2914a1bfcc9eecf8d91bab5c084d074155L15) [[5]](diffhunk://#diff-8c2643c908331a43430aedfa9a5c3f006959b1c0c29feb975cf45ece8830b8d7L17) [[6]](diffhunk://#diff-23baa78319a7052e993f6ca661ab309cf3f43dbcdf2e2ab0782ddb859f0adec0L15) [[7]](diffhunk://#diff-cef30475cb7daff0cdd5651691253c9f22bf28fbaa91336867c2dca24cfa7d44L12) [[8]](diffhunk://#diff-2abfd9960a0cf80a1c8c57d1290dfbabc3adbcd0476fcb8b101b7459723d8f34L10-R14)

**Type annotation improvements:**

* Updated the type annotation for the `kind` parameter in the `date_range` function to use a forward reference (`"Format"`) for compatibility.

These changes make the codebase more maintainable and less error-prone by centralizing formatting options within the `ExtendedDatetime` class.…stants across multiple files