### PR TITLE
Revert project version to 0.14.10 from 0.14.10-test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mahjong-score-management"
-version = "0.14.10-test"
+version = "0.14.10"
 description = "Mahjong score management tool"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
This pull request makes a small change to the project version in `pyproject.toml`, updating it from a test version to the official release version.