### PR TITLE
Update GitHub Actions workflow for deployment to v4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,8 @@ jobs:
           cp -r ./temp_docs/user/build/html ./temp_docs/html/user
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: actions/deploy-pages@v4
+
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./temp_docs/html/


### PR DESCRIPTION
This pull request updates the deployment step in the documentation workflow to use a newer GitHub Action for deploying to GitHub Pages.

Deployment workflow update:

* Replaced the use of `peaceiris/actions-gh-pages@v3` with the official `actions/deploy-pages@v4` action in the `.github/workflows/docs.yml` file to handle deployment to GitHub Pages.… deployment