### PR TITLE
Update GitHub Actions for documentation deployment permissions and artifact upload

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -35,9 +40,10 @@ jobs:
           uv run sphinx-build -M html ./docs/user/source/ ./temp_docs/user/build --conf-dir ./docs/user/
           cp -r ./temp_docs/user/build/html ./temp_docs/html/user
 
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./temp_docs/html/
+
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
-
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./temp_docs/html/


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for documentation deployment to better align with the latest GitHub Pages deployment practices. The main changes involve updating permissions, using the recommended artifact upload step, and simplifying deployment configuration.

**Workflow and Deployment Improvements:**

* Added explicit permissions for `contents: read`, `pages: write`, and `id-token: write` to the workflow, enhancing security and compatibility with GitHub Pages deployment.
* Added a step to upload the built documentation as a GitHub Pages artifact using `actions/upload-pages-artifact@v3`, following best practices for Pages deployments.
* Simplified the deployment step by removing the manual `publish_dir` and `github_token` configuration, relying on the artifact upload and default settings of `actions/deploy-pages@v4`.…tep for documentation deployment