### PR TITLE
Refactor GitHub Actions workflow for deployment step

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -40,10 +35,8 @@ jobs:
           uv run sphinx-build -M html ./docs/user/source/ ./temp_docs/user/build --conf-dir ./docs/user/
           cp -r ./temp_docs/user/build/html ./temp_docs/html/user
 
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./temp_docs/html/
-
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./temp_docs/html/


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for documentation deployment. The main change is switching from the official GitHub Pages deployment actions to the `peaceiris/actions-gh-pages` action, simplifying the deployment process and removing unnecessary permissions and artifact upload steps.

**Workflow deployment changes:**

* Replaced the use of `actions/upload-pages-artifact` and `actions/deploy-pages` with the `peaceiris/actions-gh-pages` action for deploying documentation to GitHub Pages, streamlining the deployment process (`.github/workflows/docs.yml`).
* Removed explicit workflow permissions (`contents: read`, `pages: write`, `id-token: write`) from the workflow configuration, as they are no longer needed with the new deployment method (`.github/workflows/docs.yml`).…te deployment step to use peaceiris/actions-gh-pages@v3