### PR TITLE
Enhance documentation with Sphinx directives and type annotations

### DIFF
--- a/integrations/discord/adapter.py
+++ b/integrations/discord/adapter.py
@@ -20,7 +20,7 @@ class ServiceAdapter(AdapterInterface[SvcConfig, AdapterAPI, SvcFunctions, Messa
 
     interface_type = ServiceType.DISCORD
 
-    def __init__(self, parser: "ConfigParser"):
+    def __init__(self, parser: "ConfigParser") -> None:
         self.conf = SvcConfig(main_conf=parser)
         self.api = AdapterAPI()
         self.functions = SvcFunctions(api=self.api, conf=self.conf)

--- a/integrations/slack/adapter.py
+++ b/integrations/slack/adapter.py
@@ -20,7 +20,7 @@ class ServiceAdapter(AdapterInterface[SvcConfig, AdapterAPI, SvcFunctions, Messa
 
     interface_type = ServiceType.SLACK
 
-    def __init__(self, parser: "ConfigParser"):
+    def __init__(self, parser: "ConfigParser") -> None:
         self.conf = SvcConfig(main_conf=parser)
         self.api = AdapterAPI()
         self.functions = SvcFunctions(api=self.api, conf=self.conf)

--- a/integrations/slack/functions.py
+++ b/integrations/slack/functions.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 class SvcFunctions(FunctionsInterface):
     """slack専用関数"""
 
-    def __init__(self, api: "AdapterAPI", conf: "SvcConfig"):
+    def __init__(self, api: "AdapterAPI", conf: "SvcConfig") -> None:
         super().__init__()
 
         try:

--- a/integrations/standard_io/__init__.py
+++ b/integrations/standard_io/__init__.py
@@ -1,9 +1,9 @@
 """
 標準出力
 
-- `integrations.standard_io.adapter`: サービスアダプタ定義
-- `integrations.standard_io.api`: インターフェースAPI
-- `integrations.standard_io.parser`: メッセージ解析クラス
-- `integrations.standard_io.functions`: 専用関数群
-- `integrations.standard_io.config`: 個別設定
+- :doc:`integrations.standard_io.adapter`: サービスアダプタ定義
+- :doc:`integrations.standard_io.api`: インターフェースAPI
+- :doc:`integrations.standard_io.parser`: メッセージ解析クラス
+- :doc:`integrations.standard_io.functions`: 専用関数群
+- :doc:`integrations.standard_io.config`: 個別設定
 """

--- a/integrations/standard_io/adapter.py
+++ b/integrations/standard_io/adapter.py
@@ -20,7 +20,7 @@ class ServiceAdapter(AdapterInterface[SvcConfig, AdapterAPI, SvcFunctions, Messa
 
     interface_type = ServiceType.STANDARD_IO
 
-    def __init__(self, parser: "ConfigParser"):
+    def __init__(self, parser: "ConfigParser") -> None:
         self.conf = SvcConfig(main_conf=parser)
         self.api = AdapterAPI()
         self.functions = SvcFunctions()

--- a/integrations/standard_io/events/__init__.py
+++ b/integrations/standard_io/events/__init__.py
@@ -1,5 +1,5 @@
 """
 イベント処理
 
-- `integrations.standard_io.events.handler`: イベントハンドラ
+- :doc:`integrations.standard_io.events.handler`: イベントハンドラ
 """

--- a/integrations/web/adapter.py
+++ b/integrations/web/adapter.py
@@ -20,7 +20,7 @@ class ServiceAdapter(AdapterInterface[SvcConfig, AdapterAPI, SvcFunctions, Messa
 
     interface_type = ServiceType.WEB
 
-    def __init__(self, parser: "ConfigParser"):
+    def __init__(self, parser: "ConfigParser") -> None:
         self.conf = SvcConfig(main_conf=parser)
         self.api = AdapterAPI()
         self.functions = SvcFunctions()

--- a/libs/utils/timekit.py
+++ b/libs/utils/timekit.py
@@ -213,7 +213,7 @@ class ExtendedDatetime:
     - **datetime** / **ExtendedDatetime**: オブジェクトをそのまま利用
     """
 
-    def __init__(self, value: Optional[AcceptedType] = None, **relativedelta_kwargs: Any):
+    def __init__(self, value: Optional[AcceptedType] = None, **relativedelta_kwargs: Any) -> None:
         """
         ExtendedDatetimeの初期化
 


### PR DESCRIPTION
This pull request makes minor improvements to type annotations and documentation formatting across several integration modules and a utility class. The changes mainly add explicit return type annotations to `__init__` methods and update docstring references for better clarity.

Type annotation improvements:

* Added explicit `-> None` return type annotations to the `__init__` methods of `ServiceAdapter` classes in `discord`, `slack`, `standard_io`, and `web` adapters, as well as to `SvcFunctions` in `slack/functions.py` and `ExtendedDatetime` in `libs/utils/timekit.py`. [[1]](diffhunk://#diff-39a3160649d575c22ef1a69752a8663d938c8fe4757a802133790c77b60abc26L23-R23) [[2]](diffhunk://#diff-281b82a6d6c5f83439e0cac485dd0287a133c0f9e99dbe322d6bc8f97f019d3eL23-R23) [[3]](diffhunk://#diff-9f693e69cc1ad2d908da4b969daae5da5251d8e6b491032ebbc5872e52d04fddL23-R23) [[4]](diffhunk://#diff-d5bfa4ac4733eca6dc1e2bc71fb6cd5f984f97aa3d9abf11d1c351ab7e0459a4L23-R23) [[5]](diffhunk://#diff-cef30475cb7daff0cdd5651691253c9f22bf28fbaa91336867c2dca24cfa7d44L26-R26) [[6]](diffhunk://#diff-203ac1a47521b7ac9b0c7c03c8e282c8ba21d0a1d238228f83c9469764b2c5baL216-R216)

Documentation formatting updates:

* Updated docstrings in `integrations/standard_io/__init__.py` and `integrations/standard_io/events/__init__.py` to use the `:doc:` directive for module references, improving documentation formatting. [[1]](diffhunk://#diff-a4050658e315febba8edfa3c394a032900b6b518756447a6e75b22af855b487bL4-R8) [[2]](diffhunk://#diff-1c18508d54fe0c4b796aa050e05c48c450208c86e440ca669cfb873a72059018L4-R4)