### PR TITLE
Enhance __init__ docstrings and update ruff configuration

### DIFF
--- a/integrations/discord/adapter.py
+++ b/integrations/discord/adapter.py
@@ -21,6 +21,13 @@ class ServiceAdapter(AdapterInterface[SvcConfig, AdapterAPI, SvcFunctions, Messa
     interface_type = ServiceType.DISCORD
 
     def __init__(self, parser: "ConfigParser") -> None:
+        """
+        Discord連携用アダプタを初期化する。
+
+        Args:
+            parser (ConfigParser): アプリケーション設定を保持する設定パーサー。
+
+        """
         self.conf = SvcConfig(main_conf=parser)
         self.api = AdapterAPI()
         self.functions = SvcFunctions(api=self.api, conf=self.conf)

--- a/integrations/discord/api.py
+++ b/integrations/discord/api.py
@@ -31,6 +31,7 @@ class AdapterAPI(APIInterface):
     bot: "Bot"
 
     def __init__(self) -> None:
+        """Discord APIラッパーで利用する依存オブジェクトを初期化する。"""
         super().__init__()
 
         from discord import File as discord_file

--- a/integrations/discord/functions.py
+++ b/integrations/discord/functions.py
@@ -24,6 +24,14 @@ class SvcFunctions(FunctionsInterface):
     """discord専用関数"""
 
     def __init__(self, api: "AdapterAPI", conf: "SvcConfig") -> None:
+        """
+        Discord向け関数オブジェクトを初期化する。
+
+        Args:
+            api (AdapterAPI): Discord連携で利用するAPIラッパー。
+            conf (SvcConfig): Discord向け設定情報。
+
+        """
         super().__init__()
 
         self.api = api

--- a/integrations/discord/parser.py
+++ b/integrations/discord/parser.py
@@ -20,6 +20,7 @@ class MessageParser(MessageParserDataMixin, MessageParserInterface):
     """メッセージ解析クラス"""
 
     def __init__(self) -> None:
+        """Discordメッセージ解析に必要な状態を初期化する。"""
         MessageParserDataMixin.__init__(self)
         self.data: MsgData = MsgData()
         self.post: PostData = PostData()

--- a/integrations/slack/adapter.py
+++ b/integrations/slack/adapter.py
@@ -21,6 +21,13 @@ class ServiceAdapter(AdapterInterface[SvcConfig, AdapterAPI, SvcFunctions, Messa
     interface_type = ServiceType.SLACK
 
     def __init__(self, parser: "ConfigParser") -> None:
+        """
+        Slack連携用アダプタを初期化する。
+
+        Args:
+            parser (ConfigParser): アプリケーション設定を保持する設定パーサー。
+
+        """
         self.conf = SvcConfig(main_conf=parser)
         self.api = AdapterAPI()
         self.functions = SvcFunctions(api=self.api, conf=self.conf)

--- a/integrations/slack/api.py
+++ b/integrations/slack/api.py
@@ -30,6 +30,7 @@ class AdapterAPI(APIInterface):
     """WebClient(userトークン使用)"""
 
     def __init__(self) -> None:
+        """Slack APIクライアント関連の初期設定を行う。"""
         super().__init__()
 
         try:

--- a/integrations/slack/functions.py
+++ b/integrations/slack/functions.py
@@ -24,6 +24,14 @@ class SvcFunctions(FunctionsInterface):
     """slack専用関数"""
 
     def __init__(self, api: "AdapterAPI", conf: "SvcConfig") -> None:
+        """
+        Slack向け関数オブジェクトを初期化する。
+
+        Args:
+            api (AdapterAPI): Slack連携で利用するAPIラッパー。
+            conf (SvcConfig): Slack向け設定情報。
+
+        """
         super().__init__()
 
         try:

--- a/integrations/slack/parser.py
+++ b/integrations/slack/parser.py
@@ -18,6 +18,7 @@ class MessageParser(MessageParserDataMixin, MessageParserInterface):
     """メッセージ解析クラス"""
 
     def __init__(self) -> None:
+        """Slackメッセージ解析に必要な状態を初期化する。"""
         MessageParserDataMixin.__init__(self)
         self.data: MsgData = MsgData()
         self.post: PostData = PostData()

--- a/integrations/standard_io/adapter.py
+++ b/integrations/standard_io/adapter.py
@@ -21,6 +21,13 @@ class ServiceAdapter(AdapterInterface[SvcConfig, AdapterAPI, SvcFunctions, Messa
     interface_type = ServiceType.STANDARD_IO
 
     def __init__(self, parser: "ConfigParser") -> None:
+        """
+        標準入出力連携用アダプタを初期化する。
+
+        Args:
+            parser (ConfigParser): アプリケーション設定を保持する設定パーサー。
+
+        """
         self.conf = SvcConfig(main_conf=parser)
         self.api = AdapterAPI()
         self.functions = SvcFunctions()

--- a/integrations/standard_io/parser.py
+++ b/integrations/standard_io/parser.py
@@ -14,6 +14,7 @@ class MessageParser(MessageParserDataMixin, MessageParserInterface):
     """メッセージ解析クラス"""
 
     def __init__(self) -> None:
+        """標準入出力メッセージ解析の初期状態を構築する。"""
         MessageParserDataMixin.__init__(self)
         self.data: MsgData = MsgData()
         self.post: PostData = PostData()

--- a/integrations/web/adapter.py
+++ b/integrations/web/adapter.py
@@ -21,6 +21,13 @@ class ServiceAdapter(AdapterInterface[SvcConfig, AdapterAPI, SvcFunctions, Messa
     interface_type = ServiceType.WEB
 
     def __init__(self, parser: "ConfigParser") -> None:
+        """
+        Web連携用アダプタを初期化する。
+
+        Args:
+            parser (ConfigParser): アプリケーション設定を保持する設定パーサー。
+
+        """
         self.conf = SvcConfig(main_conf=parser)
         self.api = AdapterAPI()
         self.functions = SvcFunctions()

--- a/integrations/web/parser.py
+++ b/integrations/web/parser.py
@@ -17,6 +17,7 @@ class MessageParser(MessageParserDataMixin, MessageParserInterface):
     status: StatusData
 
     def __init__(self) -> None:
+        """Webメッセージ解析に必要な状態を初期化する。"""
         MessageParserDataMixin.__init__(self)
         self.data = MsgData()
         self.post = PostData()

--- a/libs/commands/registry/member.py
+++ b/libs/commands/registry/member.py
@@ -62,6 +62,13 @@ class MemberSection(BaseSection):
     """未登録メンバー名称"""
 
     def __init__(self, outer: "AppConfig") -> None:
+        """
+        memberセクション設定の初期値を準備する。
+
+        Args:
+            outer (AppConfig): 共通設定を保持するアプリケーション設定オブジェクト。
+
+        """
         self.default_commandword = "メンバー一覧"
         self.section = str(CommandType.MEMBER_LIST)
         self.main_parser = outer.main_parser

--- a/libs/commands/registry/team.py
+++ b/libs/commands/registry/team.py
@@ -55,6 +55,13 @@ class TeamSection(BaseSection):
     """チームメイトが同卓しているゲームを集計対象に含めるか"""
 
     def __init__(self, outer: "AppConfig") -> None:
+        """
+        teamセクション設定の初期値を準備する。
+
+        Args:
+            outer (AppConfig): 共通設定を保持するアプリケーション設定オブジェクト。
+
+        """
         self.default_commandword = "チーム一覧"
         self.section = str(CommandType.TEAM_LIST)
         self.main_parser = outer.main_parser

--- a/libs/domain/command.py
+++ b/libs/domain/command.py
@@ -187,6 +187,7 @@ class CommandParser:
     """引数解析クラス"""
 
     def __init__(self) -> None:
+        """日付文字列判定に使う正規表現を初期化する。"""
         self.day_format = re.compile(r"^([0-9]{8}|[0-9/.-]{8,10})$")
         """日付文字列判定用正規表現
 

--- a/libs/domain/rule.py
+++ b/libs/domain/rule.py
@@ -106,6 +106,7 @@ class RuleSet:
     """ルールセット"""
 
     def __init__(self) -> None:
+        """ルール設定と派生キャッシュの格納先を初期化する。"""
         self.config: ConfigParser = ConfigParser()
         """ルール設定ファイル"""
         self.data: dict[str, RuleData] = {}

--- a/libs/domain/section.py
+++ b/libs/domain/section.py
@@ -174,6 +174,13 @@ class BaseSection(CommonMethodMixin):
     """読み込み先(パーサー + セクション名)"""
 
     def __init__(self, outer: SubClassType) -> None:
+        """
+        設定パーサーから対象セクションを初期化する。
+
+        Args:
+            outer (SubClassType): main_parser を保持する外部設定オブジェクト。
+
+        """
         self.main_parser = outer.main_parser
         assert self.main_parser
         if not hasattr(self, "section") or self.section not in self.main_parser:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ ignore = [
     "N813",  # Camelcase `Xxx` imported as lowercase `xxx`
     "D102",  # Missing docstring in public method
     "D105",  # Missing docstring in magic method
-    "D107",  # Missing docstring in `__init__`
     "D200",  # One-line docstring should fit on one line
     "D203",  # 1 blank line required before class docstring
     "D202",  # No blank lines allowed after function docstring


### PR DESCRIPTION
This pull request primarily adds detailed docstrings to the `__init__` methods across various adapter, API, function, and parser classes for Discord, Slack, Standard IO, and Web integrations, as well as several core library classes. These docstrings describe the purpose of each constructor and its arguments, improving code readability and maintainability. Additionally, the linter configuration is updated to require docstrings for `__init__` methods.

The most important changes are:

**Docstring Additions (Adapters, APIs, Functions, Parsers):**
* Added descriptive docstrings to the `__init__` methods of `ServiceAdapter`, `AdapterAPI`, `SvcFunctions`, and `MessageParser` classes for Discord (`integrations/discord/adapter.py`, `api.py`, `functions.py`, `parser.py`), Slack (`integrations/slack/adapter.py`, `api.py`, `functions.py`, `parser.py`), Standard IO (`integrations/standard_io/adapter.py`, `parser.py`), and Web (`integrations/web/adapter.py`, `parser.py`) integrations, clarifying initialization logic and argument usage. [[1]](diffhunk://#diff-39a3160649d575c22ef1a69752a8663d938c8fe4757a802133790c77b60abc26R24-R30) [[2]](diffhunk://#diff-e70f2c4ac2e5530abf5bae8dede764a1abe586aec1781fb4dd21c822d3828c7bR34) [[3]](diffhunk://#diff-f8f1eb9e16368a63e337c09b04697116a1569feb35ca55b16ccba128d064903fR27-R34) [[4]](diffhunk://#diff-6d058926728a6b11a635dd4b83e5f144b17c3cd4a12b41681963950479211475R23) [[5]](diffhunk://#diff-281b82a6d6c5f83439e0cac485dd0287a133c0f9e99dbe322d6bc8f97f019d3eR24-R30) [[6]](diffhunk://#diff-c5bb1d09c9ee7902c6ccfdd9a3b6f9cea1101bc69fd2d9d6a4dd1caee050bb92R33) [[7]](diffhunk://#diff-cef30475cb7daff0cdd5651691253c9f22bf28fbaa91336867c2dca24cfa7d44R27-R34) [[8]](diffhunk://#diff-8210fd02189a56ec626b50250ffecb24f0cc98ce16b46ebda41721243e282e97R21) [[9]](diffhunk://#diff-9f693e69cc1ad2d908da4b969daae5da5251d8e6b491032ebbc5872e52d04fddR24-R30) [[10]](diffhunk://#diff-58cb6902680c277861a8021d722f188a8ee3ef2b7c201c92d9c1741557064801R17) [[11]](diffhunk://#diff-d5bfa4ac4733eca6dc1e2bc71fb6cd5f984f97aa3d9abf11d1c351ab7e0459a4R24-R30) [[12]](diffhunk://#diff-71cf0b9208fa1de0ffc21d156583a474052dc4cea442282efe13380f4464a71bR20)

**Docstring Additions (Core Libraries):**
* Added docstrings to constructors in core library classes, including `MemberSection` (`libs/commands/registry/member.py`), `TeamSection` (`libs/commands/registry/team.py`), `CommandParser` (`libs/domain/command.py`), `RuleSet` (`libs/domain/rule.py`), and `BaseSection` (`libs/domain/section.py`), explaining their initialization responsibilities and arguments. [[1]](diffhunk://#diff-0e3cabd708a159e090882ad6df087ebb438a78faf65d803150bd5d2b7a395029R65-R71) [[2]](diffhunk://#diff-e714f0a619367d58ae2d1b302e0bb27ab8aacd62d1dfd696d0ee1a6e42cbb7dcR58-R64) [[3]](diffhunk://#diff-8fdd00b47d992be4d98b1ac167dab0d89b31c8fb54a7b656f54a12713039a1b8R190) [[4]](diffhunk://#diff-05175ba2abccf7c80dd601ce59a856abfa549ff65da04999d48dfcef54b12efbR109) [[5]](diffhunk://#diff-d2d3197229f61bfab42d654bd57c7d0d34434f0df1ce70f8acf6f83a6b4c0f6eR177-R183)

**Linter Configuration Update:**
* Updated `pyproject.toml` to remove the ignore rule for missing docstrings in `__init__` methods (`D107`), enforcing docstring requirements for constructors.