### PR TITLE
Update Japanese translations and enhance regression plotting

### DIFF
--- a/libs/commands/graph/regression.py
+++ b/libs/commands/graph/regression.py
@@ -10,8 +10,11 @@ import statsmodels.api as sm  # type: ignore[import-untyped]
 from matplotlib.lines import Line2D
 
 import libs.global_value as g
+from libs.domain.datamodels import GameInfo
+from libs.functions import message
 from libs.types import StyleOptions
 from libs.utils import graphutil, textutil
+from libs.utils.timekit import Format
 
 if TYPE_CHECKING:
     from integrations.protocols import MessageParserProtocol
@@ -32,6 +35,16 @@ def plot(m: "MessageParserProtocol") -> None:
 
     # 足切り
     df = df.query("count >= @g.params.stipulated")
+    if df.empty:
+        m.set_headline(message.random_reply(m, "no_target"), StyleOptions())
+        m.status.result = False
+        return
+
+    # 情報ヘッダ
+    game_info = GameInfo()
+    title_text = "順位素点相関図"
+    starttime = g.params.starttime.format(fmt=Format.YMDHM)
+    endtime = g.params.endtime.format(fmt=Format.YMDHM)
 
     # --- グラフ生成
     graphutil.setup()
@@ -73,32 +86,34 @@ def plot(m: "MessageParserProtocol") -> None:
                 color="w",
                 markerfacecolor=color,
                 markersize=7,
-                label=f"{name} : {row['rank_avg']:.2f}位 / {row['rpoint_avg']:.1f}点 / {row['resid_ols']:.1f}",
+                label=f"{name} : {row['count']}G / {row['rank_avg']:.2f}位 / {row['rpoint_avg']:.1f}点 / {row['resid_ols']:.1f}",
             )
         )
 
     # 通常回帰線
-    (ols_line,) = plt.plot(x_line, y_ols, color="red", label="OLS regression")
+    (ols_line,) = plt.plot(x_line, y_ols, color="red", label="通常回帰線")
 
     # 重み付き回帰線
-    (wls_line,) = plt.plot(x_line, y_wls, color="blue", linestyle="--", label="Weighted regression")
+    (wls_line,) = plt.plot(x_line, y_wls, color="blue", linestyle="--", label="重み付き回帰線")
 
-    plt.xlabel("Average Rank")
-    plt.ylabel("Average Score")
+    plt.xlabel("平均順位")
+    plt.ylabel("平均素点")
     plt.xlim(0.9, 4.1)
     plt.xticks(np.arange(1.0, 4.1, 0.5))
-    plt.title("Player Performance: Rank vs Score")
+    plt.title(f"{title_text} ({starttime} - {endtime})")
+
+    # 凡例
     plt.legend(
-        handles=[ols_line, wls_line, *player_handles],
+        title="ゲーム数 / 平均順位 / 平均素点 / 残差",
+        handles=[*player_handles, ols_line, wls_line],
         loc="upper left",
         bbox_to_anchor=(1.02, 1.0),
         borderaxespad=0.0,
         ncol=int(len(df) / 25 + 1),
     )
-    plt.grid(True)
 
+    plt.grid(True)
     plt.savefig(save_file, bbox_inches="tight")
-    m.set_message(
-        save_file,
-        StyleOptions(title="Player Performance: Rank vs Score", use_comment=True, header_hidden=True, key_title=False),
-    )
+
+    m.set_headline(message.header(game_info, m), StyleOptions(title=title_text))
+    m.set_message(save_file, StyleOptions(title=title_text, use_comment=True, key_title=False))

--- a/libs/utils/dictutil.py
+++ b/libs/utils/dictutil.py
@@ -286,10 +286,10 @@ def rename_dicts(columns: list[str], options: StyleOptions) -> dict[str, str]:
         "rank3_balance": "3位収支",
         "rank4_balance": "4位収支",
         # 素点分析
-        "rank1_avg_diff": "1位差分",
-        "rank2_avg_diff": "2位差分",
-        "rank3_avg_diff": "3位差分",
-        "rank4_avg_diff": "4位差分",
+        "rank1_avg_diff": "1位偏差",
+        "rank2_avg_diff": "2位偏差",
+        "rank3_avg_diff": "3位偏差",
+        "rank4_avg_diff": "4位偏差",
         # レコード
         "top1_max": "連続トップ",
         "top2_max": "連続連対",


### PR DESCRIPTION
This pull request updates the regression graph plotting function and related utilities to improve user feedback, enhance localization, and clarify data presentation. The main changes include handling empty data cases, updating plot labels to Japanese, and refining terminology for consistency.

**User feedback and error handling:**

* Added a check in `plot` (`libs/commands/graph/regression.py`) to handle cases where the filtered DataFrame is empty, providing a user-friendly message and preventing further processing.

**Localization and label improvements:**

* Updated all axis labels, plot titles, and legend texts in the regression graph to Japanese, and included the analysis period in the title for better context.
* Changed the order and content of legend handles to prioritize player data and clarified the legend title.

**Data presentation and terminology:**

* Modified player labels in the graph to include the number of games (`count`) for each player, making the plot more informative.
* Updated terminology in `rename_dicts` (`libs/utils/dictutil.py`) from "差分" (difference) to "偏差" (deviation) for rank average differences, improving consistency and accuracy in data descriptions.

**Code organization:**

* Added imports for `GameInfo`, `message`, and `Format` to support the new features and maintain code clarity.