### PR TITLE
Refactor time formatting in plot function for consistency

### DIFF
--- a/libs/commands/graph/regression.py
+++ b/libs/commands/graph/regression.py
@@ -14,7 +14,7 @@ from libs.domain.datamodels import GameInfo
 from libs.functions import message
 from libs.types import StyleOptions
 from libs.utils import graphutil, textutil
-from libs.utils.timekit import Format
+from libs.utils.timekit import ExtendedDatetime as ExtDt
 
 if TYPE_CHECKING:
     from integrations.protocols import MessageParserProtocol
@@ -43,8 +43,8 @@ def plot(m: "MessageParserProtocol") -> None:
     # 情報ヘッダ
     game_info = GameInfo()
     title_text = "順位素点相関図"
-    starttime = g.params.starttime.format(fmt=Format.YMDHM)
-    endtime = g.params.endtime.format(fmt=Format.YMDHM)
+    starttime = ExtDt(g.params.starttime).format(fmt=ExtDt.FMT.YMDHM)
+    endtime = ExtDt(g.params.endtime).format(fmt=ExtDt.FMT.YMDHM)
 
     # --- グラフ生成
     graphutil.setup()


### PR DESCRIPTION
This pull request updates the way date and time formatting is handled in the `libs/commands/graph/regression.py` file. The main change is replacing the use of the `Format` class with the new `ExtendedDatetime` (`ExtDt`) class for formatting start and end times in the plot function.

Date and time formatting improvements:

* Replaced import of `Format` from `libs.utils.timekit` with `ExtendedDatetime` as `ExtDt`, and updated usage in the `plot` function to use `ExtDt` for formatting `starttime` and `endtime`. [[1]](diffhunk://#diff-94fbf8c1eacff814d4acf7a09ebafc080ac6622e6de4e18a75e620726c8c5897L17-R17) [[2]](diffhunk://#diff-94fbf8c1eacff814d4acf7a09ebafc080ac6622e6de4e18a75e620726c8c5897L46-R47)… consistency