### PR TITLE
Enhance save_output function and refactor statistics output

### DIFF
--- a/libs/commands/results/summary.py
+++ b/libs/commands/results/summary.py
@@ -289,11 +289,7 @@ def statistics(m: "MessageParserProtocol") -> None:
     rank_df = rank_df.query("count >= @g.params.stipulated")
 
     # 情報ヘッダ
-    if g.params.individual:  # 個人分析
-        headline_title = "素点分析"
-    else:  # チーム分析
-        headline_title = "チーム素点サマリ"
-
+    headline_title = "素点分析"
     header_text = message.header(game_info, m, "", 1)
     m.set_headline(header_text, StyleOptions(title=headline_title))
 
@@ -301,19 +297,25 @@ def statistics(m: "MessageParserProtocol") -> None:
     rank_df.drop(columns=dictutil.dropitems_list(rank_df.columns.to_list()), inplace=True)
 
     options = StyleOptions(
-        title="素点分析",
+        title=headline_title,
+        base_name="score_deviation",
         show_index=True,
         codeblock=False,
         rename_type=StyleOptions.RenameType.SHORT,
         data_kind=StyleOptions.DataKind.SCORE_ANALYSIS,
     )
 
-    if options.format_type == "default":
-        options.codeblock = True
-        data = rank_df
-    else:
-        options.title = headline_title
-        options.base_name = "summary"
-        rank_df = rank_df.fillna("*****")
-        data = converter.save_output(rank_df, options, m.post.headline)
+    match g.params.format.lower():
+        case "csv":
+            options.format_type = "csv"
+            data = converter.save_output(rank_df.fillna("*****"), options, m.post.headline)
+        case "txt" | "text":
+            options.format_type = "txt"
+            rank_df = converter.adjusting.add_units(rank_df.fillna("*****"))
+            data = converter.save_output(rank_df, options, m.post.headline)
+        case _:
+            options.format_type = "default"
+            options.codeblock = True
+            data = rank_df
+
     m.set_message(data, StyleOptions(**options.asdict))

--- a/libs/utils/converter.py
+++ b/libs/utils/converter.py
@@ -45,6 +45,9 @@ def save_output(
     # カラムリネーム
     options.rename_type = StyleOptions.RenameType.NORMAL
     df.rename(columns=dictutil.rename_dicts(df.columns.to_list(), options), inplace=True)
+    if options.show_index and df.index.name:
+        if new_index := dictutil.rename_dicts([df.index.name], options).get(df.index.name):
+            df.index.name = new_index
     if options.transpose:
         df = df.T
 


### PR DESCRIPTION
This pull request enhances the flexibility and clarity of the score analysis summary output, allowing for more customizable formatting and improved handling of index names during data export. The main changes focus on making the output format selection more explicit and ensuring consistent naming in exported data.

**Output formatting improvements:**
- The `statistics` function in `summary.py` now uses a `match` statement to explicitly select between CSV, TXT, and default output formats based on the value of `g.params.format`, making the code more readable and flexible. The `StyleOptions` are adjusted accordingly, and the `base_name` is set to `"score_deviation"` for consistency.

**Data export enhancements:**
- In `converter.py`, when exporting data, the index name is now also renamed according to the selected `StyleOptions`, ensuring that both column and index names are consistently formatted in the output.