### PR TITLE
Refactor statistics processing and fix index name check

### DIFF
--- a/libs/commands/results/summary.py
+++ b/libs/commands/results/summary.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 import libs.global_value as g
 from libs.domain.datamodels import GameInfo
-from libs.functions import message
+from libs.functions import adjusting, message
 from libs.types import StyleOptions
 from libs.utils import converter, dictutil
 
@@ -311,7 +311,7 @@ def statistics(m: "MessageParserProtocol") -> None:
             data = converter.save_output(rank_df.fillna("*****"), options, m.post.headline)
         case "txt" | "text":
             options.format_type = "txt"
-            rank_df = converter.adjusting.add_units(rank_df.fillna("*****"))
+            rank_df = adjusting.add_units(rank_df.fillna("*****"))
             data = converter.save_output(rank_df, options, m.post.headline)
         case _:
             options.format_type = "default"

--- a/libs/utils/converter.py
+++ b/libs/utils/converter.py
@@ -45,7 +45,7 @@ def save_output(
     # カラムリネーム
     options.rename_type = StyleOptions.RenameType.NORMAL
     df.rename(columns=dictutil.rename_dicts(df.columns.to_list(), options), inplace=True)
-    if options.show_index and df.index.name:
+    if options.show_index and isinstance(df.index.name, str):
         if new_index := dictutil.rename_dicts([df.index.name], options).get(df.index.name):
             df.index.name = new_index
     if options.transpose:


### PR DESCRIPTION
This pull request primarily focuses on improving code clarity and robustness by refining import statements, function references, and index renaming logic. The most important changes are grouped below:

**Code organization and clarity:**

* Changed the import of `adjusting` in `libs/commands/results/summary.py` to a direct import, and updated the call to `add_units` to reference the new import, improving code readability and modularity. [[1]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eL12-R12) [[2]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eL314-R314)

**Bug fix and robustness:**

* Updated the index renaming logic in `libs/utils/converter.py` to check if `df.index.name` is a string before attempting to rename, preventing potential errors when the index name is not set or is not a string.