### PR TITLE
Enhance post message formatting and unit handling for metrics

### DIFF
--- a/integrations/slack/api.py
+++ b/integrations/slack/api.py
@@ -134,6 +134,8 @@ class AdapterAPI(APIInterface):
                         post_msg.extend(_table_data(converter.df_to_ranking(data, options.title, step=50)))
                     case StyleOptions.DataKind.RATING:
                         post_msg.extend(_table_data(converter.df_to_text_table(data, options, step=20)))
+                    case StyleOptions.DataKind.SCORE_ANALYSIS:
+                        post_msg.extend(_table_data(converter.df_to_text_table(data, options, step=50)))
                     case _:
                         pass
 

--- a/libs/functions/adjusting.py
+++ b/libs/functions/adjusting.py
@@ -148,7 +148,9 @@ def add_units(df: pd.DataFrame, compact: bool = False) -> pd.DataFrame:
             case "位":
                 ret = f"{v:.0f}位" if isinstance(v, float) and v.is_integer() else f"{v:.{digits}f}位"
             case _:
-                if signed:
+                if isinstance(v, str):
+                    ret = v
+                elif signed:
                     ret = f"{v:+.{digits}f}{unit}".replace("-", "▲")
                 else:
                     ret = f"{v:.{digits}f}{unit}"

--- a/libs/utils/converter.py
+++ b/libs/utils/converter.py
@@ -133,13 +133,13 @@ def df_to_text_table(df: pd.DataFrame, options: StyleOptions, step: int = 40) ->
             if options.show_index:
                 data.append("")
             match k:
-                case "通算" | "平均" | "平均素点":
+                case "通算" | "平均":
                     data.append(f" {v:+.1f}".replace(" -", "▲"))
-                case k if str(k).endswith("位差分"):
+                case k if str(k).endswith(("位偏差", "平均素点")):
                     if pd.isna(v):
                         data.append("*****")
                     else:
-                        data.append(f" {v:+.1f}".replace(" -", "▲"))
+                        data.append(f" {v:+.1f}点".replace(" -", "▲"))
                 case "平順" | "平均順位":
                     data.append(f"{v:.2f}")
                 case "レート":


### PR DESCRIPTION
This pull request introduces improvements to data formatting and table generation logic, particularly for handling new data types and edge cases in text table output. The main changes focus on supporting a new data kind, refining how certain statistics are displayed, and making the cell formatting function more robust.

Enhancements to data kind and table generation:

* Added support for a new `SCORE_ANALYSIS` data kind in the `_post_header` function, enabling the generation of text tables for this type with a step size of 50.
* Updated the `df_to_text_table` function to:
  - Adjust which keys are matched for special formatting, now treating `"平均素点"` as a deviation-type metric rather than a summary.
  - Append "点" to values for certain metrics and handle missing values more clearly.

Improvements to cell formatting:

* Modified the `format_cell` function to correctly return string values as-is and avoid formatting them as numbers, improving robustness when handling mixed-type data.