### PR TITLE
Refactor dropitems_list to restrict hidden items by command

### DIFF
--- a/libs/commands/ranking/score_deviation.py
+++ b/libs/commands/ranking/score_deviation.py
@@ -26,6 +26,9 @@ def aggregation(m: "MessageParserProtocol") -> None:
         m (MessageParserProtocol): メッセージデータ
 
     """
+    # パラメータ切り替え
+    g.params.command = "analysis"
+
     # データ収集
     data: "MessageType"
     rank_data: dict[str, list[float]] = {}

--- a/libs/utils/dictutil.py
+++ b/libs/utils/dictutil.py
@@ -448,7 +448,7 @@ def dropitems_list(item_list: Optional[list[str]] = None) -> list[str]:
         item_list = []
 
     hide_items = g.cfg.rule.dropitems(g.params.rule_version)
-    if g.params.command:
+    if g.params.command and g.params.command in ["results", "graph", "ranking", "report"]:
         hide_items = hide_items.union(set(cast(SubCommands, getattr(g.cfg, g.params.command)).dropitems))
 
     if g.params.ignore_flying:

--- a/libs/utils/dictutil.py
+++ b/libs/utils/dictutil.py
@@ -448,7 +448,7 @@ def dropitems_list(item_list: Optional[list[str]] = None) -> list[str]:
         item_list = []
 
     hide_items = g.cfg.rule.dropitems(g.params.rule_version)
-    if g.params.command and g.params.command in ["results", "graph", "ranking", "report"]:
+    if g.params.command in ["results", "graph", "ranking", "report"]:
         hide_items = hide_items.union(set(cast(SubCommands, getattr(g.cfg, g.params.command)).dropitems))
 
     if g.params.ignore_flying:


### PR DESCRIPTION
This pull request introduces a parameter switch for command context in the ranking score deviation analysis and refines the logic for determining which items to hide based on specific commands. These changes help ensure that the correct configuration and behavior are applied depending on the command being executed.

Command context and configuration improvements:

* Added a parameter switch at the start of the `aggregation` function in `score_deviation.py`, explicitly setting `g.params.command` to `"analysis"` to ensure the correct command context is used during analysis.

* Updated the logic in `dropitems_list` in `dictutil.py` to only apply additional hidden items when `g.params.command` is one of `"results"`, `"graph"`, `"ranking"`, or `"report"`, making the function's behavior more precise and context-aware.