### PR TITLE
Improve output formatting and title handling in message display

### DIFF
--- a/integrations/slack/api.py
+++ b/integrations/slack/api.py
@@ -134,8 +134,6 @@ class AdapterAPI(APIInterface):
                         post_msg.extend(_table_data(converter.df_to_ranking(data, options.title, step=50)))
                     case StyleOptions.DataKind.RATING:
                         post_msg.extend(_table_data(converter.df_to_text_table(data, options, step=20)))
-                    case StyleOptions.DataKind.SCORE_ANALYSIS:
-                        post_msg.extend(_table_data(converter.df_to_text_table(data, options, step=50)))
                     case _:
                         pass
 

--- a/integrations/standard_io/api.py
+++ b/integrations/standard_io/api.py
@@ -63,7 +63,7 @@ class AdapterAPI(APIInterface):
         # 本文
         for data, options in m.post.message:
             if options.key_title and options.title:
-                print(options.print_title)
+                print(options.print_title, end="")
 
             match data:
                 case x if isinstance(x, str):
@@ -84,7 +84,7 @@ class AdapterAPI(APIInterface):
                     )
                     print(disp)
                 case x if isinstance(x, Path):
-                    print(f"{options.title}: {x.absolute()}")
+                    print(f"{x.absolute()}", end="")
                 case _:
                     pass
 

--- a/integrations/standard_io/api.py
+++ b/integrations/standard_io/api.py
@@ -63,7 +63,7 @@ class AdapterAPI(APIInterface):
         # 本文
         for data, options in m.post.message:
             if options.key_title and options.title:
-                print(options.print_title, end="")
+                print(options.print_title)
 
             match data:
                 case x if isinstance(x, str):
@@ -84,7 +84,7 @@ class AdapterAPI(APIInterface):
                     )
                     print(disp)
                 case x if isinstance(x, Path):
-                    print(f"{x.absolute()}", end="")
+                    print(f"\t{x.absolute()}")
                 case _:
                     pass
 

--- a/libs/commands/graph/regression.py
+++ b/libs/commands/graph/regression.py
@@ -78,6 +78,7 @@ def plot(m: "MessageParserProtocol") -> None:
     for i, (name, row) in enumerate(df.iterrows()):
         color = cmap(i)
         plt.scatter(row["rank_avg"], row["rpoint_avg"], s=row["count"] * 2, alpha=0.8, color=color)
+        resid_ols = f"{row['resid_ols']:.1f}点".replace("-", "▲")
         player_handles.append(
             Line2D(
                 [0],
@@ -86,7 +87,7 @@ def plot(m: "MessageParserProtocol") -> None:
                 color="w",
                 markerfacecolor=color,
                 markersize=7,
-                label=f"{name} : {row['count']}G / {row['rank_avg']:.2f}位 / {row['rpoint_avg']:.1f}点 / {row['resid_ols']:.1f}",
+                label=f"{name} : {row['count']}G / {row['rank_avg']:.2f} / {row['rpoint_avg']:.1f}点 / {resid_ols}",
             )
         )
 
@@ -116,4 +117,4 @@ def plot(m: "MessageParserProtocol") -> None:
     plt.savefig(save_file, bbox_inches="tight")
 
     m.set_headline(message.header(game_info, m), StyleOptions(title=title_text))
-    m.set_message(save_file, StyleOptions(title=title_text, use_comment=True, key_title=False))
+    m.set_message(save_file, StyleOptions(title=title_text, use_comment=True))

--- a/libs/commands/results/summary.py
+++ b/libs/commands/results/summary.py
@@ -64,6 +64,7 @@ def aggregation(m: "MessageParserProtocol") -> None:
     options = StyleOptions(
         title="通算ポイント",
         codeblock=False,
+        key_title=True,
         rename_type=StyleOptions.RenameType.SHORT,
         data_kind=StyleOptions.DataKind.POINTS_TOTAL,
     )
@@ -111,7 +112,7 @@ def aggregation(m: "MessageParserProtocol") -> None:
 
     # メモ(役満和了)
     if "役満和了" not in dictutil.dropitems_list():
-        options.title = "役満和了"
+        options.title = f"{headline_title}：役満和了"
         options.data_kind = StyleOptions.DataKind.REMARKS_YAKUMAN
         df_yakuman = df_remarks.query("type == 0").drop(columns=["type", "ex_point"])
 
@@ -125,7 +126,7 @@ def aggregation(m: "MessageParserProtocol") -> None:
 
     # メモ(卓外清算)
     if "卓外清算" not in dictutil.dropitems_list():
-        options.title = "卓外清算"
+        options.title = f"{headline_title}：卓外清算"
         options.data_kind = StyleOptions.DataKind.REMARKS_REGULATION
 
         if g.params.individual:  # 個人集計
@@ -143,7 +144,7 @@ def aggregation(m: "MessageParserProtocol") -> None:
 
     # メモ(その他)
     if "その他" not in dictutil.dropitems_list():
-        options.title = "その他"
+        options.title = f"{headline_title}：その他"
         options.data_kind = StyleOptions.DataKind.REMARKS_OTHER
         df_others = df_remarks.query("type == 1").drop(columns=set(df_remarks.columns) & {"type", "ex_point"})
 

--- a/libs/commands/results/summary.py
+++ b/libs/commands/results/summary.py
@@ -60,10 +60,8 @@ def aggregation(m: "MessageParserProtocol") -> None:
         m.status.result = False
         return
 
-    # 通算ポイント
+    # 共通オプション
     options = StyleOptions(
-        title="通算ポイント",
-        codeblock=False,
         key_title=True,
         rename_type=StyleOptions.RenameType.SHORT,
         data_kind=StyleOptions.DataKind.POINTS_TOTAL,
@@ -100,11 +98,13 @@ def aggregation(m: "MessageParserProtocol") -> None:
     df_summary.drop(columns=dictutil.dropitems_list(df_summary.columns.to_list()), inplace=True)
     df_remarks.drop(columns=dictutil.dropitems_list(df_remarks.columns.to_list()), inplace=True)
 
+    # 通算ポイント
     if options.format_type == "default":
+        options.title = "通算ポイント"
         options.codeblock = True
         data = df_summary.filter(items=header_list)
     else:
-        options.title = headline_title
+        options.title = f"{headline_title}：通算ポイント"
         options.base_name = "summary"
         df_summary = df_summary.filter(items=filter_list).fillna("*****")
         data = converter.save_output(df_summary, options, m.post.headline, "summary")
@@ -112,21 +112,21 @@ def aggregation(m: "MessageParserProtocol") -> None:
 
     # メモ(役満和了)
     if "役満和了" not in dictutil.dropitems_list():
-        options.title = f"{headline_title}：役満和了"
         options.data_kind = StyleOptions.DataKind.REMARKS_YAKUMAN
         df_yakuman = df_remarks.query("type == 0").drop(columns=["type", "ex_point"])
 
         if options.format_type == "default":
+            options.title = "役満和了"
             options.codeblock = False
             data = df_yakuman
         else:
+            options.title = f"{headline_title}：役満和了"
             options.base_name = "yakuman"
             data = converter.save_output(df_yakuman, options, m.post.headline, "yakuman")
         m.set_message(data, StyleOptions(**options.asdict))
 
     # メモ(卓外清算)
     if "卓外清算" not in dictutil.dropitems_list():
-        options.title = f"{headline_title}：卓外清算"
         options.data_kind = StyleOptions.DataKind.REMARKS_REGULATION
 
         if g.params.individual:  # 個人集計
@@ -135,22 +135,26 @@ def aggregation(m: "MessageParserProtocol") -> None:
             df_regulations = df_remarks.query("type == 2 or type == 3").drop(columns=["type"])
 
         if options.format_type == "default":
+            options.title = "卓外清算"
             options.codeblock = False
             data = df_regulations
         else:
+            options.title = f"{headline_title}：卓外清算"
             options.base_name = "regulations"
             data = converter.save_output(df_regulations, options, m.post.headline, "regulations")
         m.set_message(data, StyleOptions(**options.asdict))
 
     # メモ(その他)
     if "その他" not in dictutil.dropitems_list():
-        options.title = f"{headline_title}：その他"
         options.data_kind = StyleOptions.DataKind.REMARKS_OTHER
         df_others = df_remarks.query("type == 1").drop(columns=set(df_remarks.columns) & {"type", "ex_point"})
 
         if options.format_type == "default":
+            options.title = "その他"
+            options.codeblock = False
             data = df_others
         else:
+            options.title = f"{headline_title}：その他"
             options.base_name = "others"
             data = converter.save_output(df_others, options, m.post.headline, "others")
         m.set_message(data, StyleOptions(**options.asdict))

--- a/libs/utils/converter.py
+++ b/libs/utils/converter.py
@@ -75,6 +75,8 @@ def save_output(
         if headline:
             headline_data, headline_option = headline
             if options.key_title:
+                writefile.writelines(f"# 【{options.title}】\n")
+            else:
                 writefile.writelines(f"# 【{headline_option.title}】\n")
             if isinstance(headline_data, str):
                 for line in headline_data.splitlines():


### PR DESCRIPTION
This pull request mainly focuses on improving the clarity and consistency of output formatting and message labeling across several modules, especially in summary and regression graph commands. It also includes some minor code cleanups and bug fixes related to output options and message formatting.

**Output formatting and labeling improvements:**

* Standardized the use of `options.title` and related labeling for summary sections like "通算ポイント", "役満和了", "卓外清算", and "その他" in the `aggregation` function, ensuring section titles are set appropriately for both default and alternative formats. Also set `key_title=True` as a common option. [[1]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eL63-R65) [[2]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eR101-L128) [[3]](diffhunk://#diff-1018d6cca1835bd4738286aef2119a074757a10f64f4327113978602212f9f8eR138-R157)
* Improved headline writing logic in `converter.save_output` to use `options.title` when `key_title` is set, ensuring consistent section headers in output files.

**Graph regression output improvements:**

* Changed the regression graph legend to display residuals in a more readable format (e.g., replacing negative signs with "▲" and appending "点"). [[1]](diffhunk://#diff-94fbf8c1eacff814d4acf7a09ebafc080ac6622e6de4e18a75e620726c8c5897R81) [[2]](diffhunk://#diff-94fbf8c1eacff814d4acf7a09ebafc080ac6622e6de4e18a75e620726c8c5897L89-R90)
* Updated message posting to remove the `key_title` option from `StyleOptions` when sending the regression graph file, simplifying the message options.

**Minor bug fixes and cleanups:**

* Removed the unused `SCORE_ANALYSIS` case from the Slack API `_post_header` function.
* Adjusted standard output formatting for file paths to improve readability.