### PR TITLE
Refactor ranking query for readability and bump version to 0.15.1

### DIFF
--- a/files/queries/ranking/results.sql
+++ b/files/queries/ranking/results.sql
@@ -1,8 +1,30 @@
 -- ranking.results
+with target_data as (
+    select
+        --[individual] --[unregistered_replace] case when results.guest = 0 then results.name else :guest_name end as name, -- ゲスト有効
+        --[individual] --[unregistered_not_replace] case when results.guest = 0 then results.name else results.name || '(<<guest_mark>>)' end as name, -- ゲスト無効
+        --[team] results.team as name,
+        rank,
+        rpoint
+    from
+        individual_results as results
+    join game_info on
+        game_info.ts = results.ts
+    where
+        results.mode = :mode
+        and results.rule_version in (<<rule_list>>)
+        and results.playtime between :starttime and :endtime
+        --[separate] and results.source = :source
+        --[individual] --[guest_not_skip] and game_info.guest_count <= 1 -- ゲストあり(2ゲスト戦除外)
+        --[individual] --[guest_skip] and guest = 0 -- ゲストなし
+        --[individual] --[player_name] and results.name in (<<player_list>>) -- 対象プレイヤー
+        --[team] and results.team != '未所属' -- 未所属除外
+        --[team] --[friendly_fire] and same_team = 0
+        --[team] --[player_name] and results.team in (<<player_list>>) -- 対象チーム
+        --[search_word] and game_info.comment like :search_word
+)
 select
-    --[individual] --[unregistered_replace] case when results.guest = 0 then results.name else :guest_name end as name, -- ゲスト有効
-    --[individual] --[unregistered_not_replace] case when results.guest = 0 then results.name else results.name || '(<<guest_mark>>)' end as name, -- ゲスト無効
-    --[team] results.team as name,
+    name,
     count() as count,
     printf("%d+%d+%d+%d=%d",
         count(rank = 1 or null),
@@ -14,22 +36,7 @@ select
     round(avg(rpoint) * 100, 1) as rpoint_avg,
     round(avg(rank), 2) as rank_avg
 from
-    individual_results as results
-join game_info on
-    game_info.ts = results.ts
-where
-    results.mode = :mode
-    and results.rule_version in (<<rule_list>>)
-    and results.playtime between :starttime and :endtime
-    --[separate] and results.source = :source
-    --[individual] --[guest_not_skip] and game_info.guest_count <= 1 -- ゲストあり(2ゲスト戦除外)
-    --[individual] --[guest_skip] and guest = 0 -- ゲストなし
-    --[individual] --[player_name] and results.name in (<<player_list>>) -- 対象プレイヤー
-    --[team] and results.team != '未所属' -- 未所属除外
-    --[team] --[friendly_fire] and same_team = 0
-    --[team] --[player_name] and results.team in (<<player_list>>) -- 対象チーム
-    --[search_word] and game_info.comment like :search_word
+    target_data
 group by
-    --[individual] results.name
-    --[team] results.team
+    name
 ;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mahjong-score-management"
-version = "0.15.0"
+version = "0.15.1"
 description = "Mahjong score management tool"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
This pull request refactors the `results.sql` query to improve clarity and maintainability by introducing a Common Table Expression (CTE) for intermediate result processing. Additionally, it updates the project version in `pyproject.toml` to reflect these changes.

**SQL query refactoring:**

* Refactored `files/queries/ranking/results.sql` to use a CTE (`target_data`) for selecting relevant fields (`name`, `rank`, `rpoint`), and moved the aggregation logic (counts, averages, and rank distribution formatting) to the outer query for clearer separation of concerns. [[1]](diffhunk://#diff-11dfb5000459673642b47b4e50c86d1a8f7facafe6572d59d6ad3fe20930c842R2-R8) [[2]](diffhunk://#diff-11dfb5000459673642b47b4e50c86d1a8f7facafe6572d59d6ad3fe20930c842R25-R41)

**Project metadata update:**

* Bumped the project version from `0.15.0` to `0.15.1` in `pyproject.toml` to reflect the new changes.