### PR TITLE
Hide header in message output for regression plot

### DIFF
--- a/libs/commands/graph/regression.py
+++ b/libs/commands/graph/regression.py
@@ -117,4 +117,4 @@ def plot(m: "MessageParserProtocol") -> None:
     plt.savefig(save_file, bbox_inches="tight")
 
     m.set_headline(message.header(game_info, m), StyleOptions(title=title_text))
-    m.set_message(save_file, StyleOptions(title=title_text, use_comment=True))
+    m.set_message(save_file, StyleOptions(title=title_text, use_comment=True, header_hidden=True))


### PR DESCRIPTION
This pull request makes a small enhancement to the way messages are displayed by hiding the header in the message output. This is achieved by passing a new `header_hidden=True` option to the `StyleOptions` when setting the message.

* Added `header_hidden=True` to `StyleOptions` in the `m.set_message` call to hide the header in the message output (`libs/commands/graph/regression.py`).